### PR TITLE
Remove MHP_Modelling submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "server/MHP_Modelling"]
-	path = server/MHP_Modelling
-	url = https://github.com/Monash-Human-Power/MHP_Modelling.git


### PR DESCRIPTION
MHP_Modelling submodule was added to this repo back when I had the idea of using HTTP request. Since we connect everything via MQTT now, we do not need this anymore.

To check if this is fine, you should be able to run MHP web server.