### PR TITLE
Remove overlay display names

### DIFF
--- a/client/js/camera.js
+++ b/client/js/camera.js
@@ -10,8 +10,8 @@ function pushOverlayHandler(data) {
     const checkedString = activeOverlay === overlay.file ? 'checked' : '';
     radioButtonHtml += `
       <div class="form-check">
-        <input class="form-check-input" type="radio" name="${device}-overlay" id="${device}-${overlay.file}" value="${overlay.file}" ${checkedString}>
-        <label class="form-check-label" for="${device}-${overlay.file}">${overlay.name}</label>
+        <input class="form-check-input" type="radio" name="${device}-overlay" id="${device}-${overlay}" value="${overlay}" ${checkedString}>
+        <label class="form-check-label" for="${device}-${overlay}">${overlay}</label>
       </div>
     `;
   });


### PR DESCRIPTION
Now displays the filename for the display.

Expected format of mqtt topic `camera/push_overlays` is now
```json
{
  "activeOverlay": "Overlay_Demo2.py",
  "device": "primary",
  "overlays": [
    "Overlay_Demo.py",
    "Overlay_Demo2.py"
  ]
}
```

Obviously this won't be functional until MHP_Raspicam is also updated.