### PR TITLE
Remove use of RegExp lookbehinds

### DIFF
--- a/client/js/power-zone.js
+++ b/client/js/power-zone.js
@@ -130,43 +130,47 @@ function numZoneHandler(zoneValue) {
   renderZoneCards(zoneValue);
 }
 
+function isNumericString(str) {
+  return !Number.isNaN(str);
+}
+
 // eslint-disable-next-line no-unused-vars
 function formSubmitHandler(event) {
   event.preventDefault();
   const form = document.getElementById('powerZoneForm');
   const outputDict = {};
+  const inputPrefix = 'input';
+  const zonePrefix = 'zone';
   for (let index = 1; index < form.elements.length - 1; index += 1) {
     // Group up 'inputs' information
-    const inputMatch = form.elements[index].id.match(
-      /(?<input>input)(?<value>.*)/,
-    );
-    if (inputMatch) {
+    const { id } = form.elements[index];
+    if (id.startsWith(inputPrefix)) {
       let inputDict = {};
       if (outputDict.inputs) {
         inputDict = outputDict.inputs;
       }
-      inputDict[inputMatch.groups.value] = form.elements[index].value;
+      inputDict[id.substring(inputPrefix.length)] = form.elements[index].value;
       outputDict.inputs = inputDict;
-    } else {
+    } else if (
       // Group up 'zone' information
-      const zoneInputMatch = form.elements[index].id.match(
-        /(?<zone>zone\d*)(?<value>.*)/,
-      );
-      if (zoneInputMatch) {
-        let zoneDict = {};
-        // Check if there is existing dict already
-        if (outputDict[zoneInputMatch.groups.zone]) {
-          zoneDict = outputDict[zoneInputMatch.groups.zone];
-        }
-        // If user does not place any value, default value of zero.
-        if (form.elements[index].value === '') {
-          form.elements[index].value = 0;
-        }
-        zoneDict[zoneInputMatch.groups.value] = form.elements[index].value;
-        outputDict[zoneInputMatch.groups.zone] = zoneDict;
-      } else {
-        outputDict[form.elements[index].id] = form.elements[index].value;
+      id.startsWith(zonePrefix) &&
+      isNumericString(id.charAt(zonePrefix.length))
+    ) {
+      let zoneDict = {};
+      const zone = id.substring(0, zonePrefix.length + 1);
+      const value = id.substring(zonePrefix.length + 1);
+      // Check if there is existing dict already
+      if (outputDict[zone]) {
+        zoneDict = outputDict[zone];
       }
+      // If user does not place any value, default value of zero.
+      if (form.elements[index].value === '') {
+        form.elements[index].value = 0;
+      }
+      zoneDict[value] = form.elements[index].value;
+      outputDict[zone] = zoneDict;
+    } else {
+      outputDict[form.elements[index].id] = form.elements[index].value;
     }
   }
   // Submit form input here

--- a/client/js/power-zone.js
+++ b/client/js/power-zone.js
@@ -149,7 +149,8 @@ function formSubmitHandler(event) {
       if (outputDict.inputs) {
         inputDict = outputDict.inputs;
       }
-      inputDict[id.substring(inputPrefix.length)] = form.elements[index].value;
+      const inputName = id.substring(inputPrefix.length);
+      inputDict[inputName] = form.elements[index].value;
       outputDict.inputs = inputDict;
     } else if (
       // Group up 'zone' information

--- a/client/js/power-zone.js
+++ b/client/js/power-zone.js
@@ -141,37 +141,39 @@ function formSubmitHandler(event) {
   const outputDict = {};
   const inputPrefix = 'input';
   const zonePrefix = 'zone';
-  for (let index = 1; index < form.elements.length - 1; index += 1) {
-    // Group up 'inputs' information
-    const { id } = form.elements[index];
-    if (id.startsWith(inputPrefix)) {
-      let inputDict = {};
-      if (outputDict.inputs) {
-        inputDict = outputDict.inputs;
+  for (let index = 0; index < form.elements.length - 1; index += 1) {
+    if (form.elements[index].tagName !== 'BUTTON') {
+      // Group up 'inputs' information
+      const { id } = form.elements[index];
+      if (id.startsWith(inputPrefix)) {
+        let inputDict = {};
+        if (outputDict.inputs) {
+          inputDict = outputDict.inputs;
+        }
+        const inputName = id.substring(inputPrefix.length);
+        inputDict[inputName] = form.elements[index].value;
+        outputDict.inputs = inputDict;
+      } else if (
+        // Group up 'zone' information
+        id.startsWith(zonePrefix) &&
+        isNumericString(id.charAt(zonePrefix.length))
+      ) {
+        let zoneDict = {};
+        const zone = id.substring(0, zonePrefix.length + 1);
+        const value = id.substring(zonePrefix.length + 1);
+        // Check if there is existing dict already
+        if (outputDict[zone]) {
+          zoneDict = outputDict[zone];
+        }
+        // If user does not place any value, default value of zero.
+        if (form.elements[index].value === '') {
+          form.elements[index].value = 0;
+        }
+        zoneDict[value] = form.elements[index].value;
+        outputDict[zone] = zoneDict;
+      } else {
+        outputDict[form.elements[index].id] = form.elements[index].value;
       }
-      const inputName = id.substring(inputPrefix.length);
-      inputDict[inputName] = form.elements[index].value;
-      outputDict.inputs = inputDict;
-    } else if (
-      // Group up 'zone' information
-      id.startsWith(zonePrefix) &&
-      isNumericString(id.charAt(zonePrefix.length))
-    ) {
-      let zoneDict = {};
-      const zone = id.substring(0, zonePrefix.length + 1);
-      const value = id.substring(zonePrefix.length + 1);
-      // Check if there is existing dict already
-      if (outputDict[zone]) {
-        zoneDict = outputDict[zone];
-      }
-      // If user does not place any value, default value of zero.
-      if (form.elements[index].value === '') {
-        form.elements[index].value = 0;
-      }
-      zoneDict[value] = form.elements[index].value;
-      outputDict[zone] = zoneDict;
-    } else {
-      outputDict[form.elements[index].id] = form.elements[index].value;
     }
   }
   // Submit form input here


### PR DESCRIPTION
At this point in time, browsers other than Chrome do not support RegExp lookbehinds. This PR should make the power zone page work on browsers other than Chrome.

Test by running `mosquitto_sub -t power_model/generate_power_plan` in a console, loading the default plan on the DAShboard and submitting. I've tested on Chrome and Firefox.