### PR TITLE
Toggle publishing to online MQTT broker using DAShboard

### DIFF
--- a/client/js/options.js
+++ b/client/js/options.js
@@ -1,6 +1,25 @@
-/* global io */
+/* global io,
+  $
+  */
 const socket = io();
 
+// Get DAS web server settings
+socket.emit('get-server-settings');
+
+socket.on('server-settings', settings => {
+  switch (settings.publishOnline) {
+    case true:
+      $('#turnOnPublishDatabutton').click();
+      break;
+    case false:
+      $('#turnOffPublishDatabutton').click();
+      break;
+    default:
+      console.error(
+        `Unhandled publish online setting: ${settings.publishOnline}`,
+      );
+  }
+});
 // eslint-disable-next-line no-unused-vars
 function turnOnPublishData() {
   socket.emit('publish-data-on');

--- a/client/js/options.js
+++ b/client/js/options.js
@@ -1,0 +1,12 @@
+/* global io */
+const socket = io();
+
+// eslint-disable-next-line no-unused-vars
+function turnOnPublishData() {
+  socket.emit('publish-data-on');
+}
+
+// eslint-disable-next-line no-unused-vars
+function turnOffPublishData() {
+  socket.emit('publish-data-off');
+}

--- a/client/options.ejs
+++ b/client/options.ejs
@@ -13,6 +13,38 @@
     <div id="main">
       <div class="col-md-12">
         <h1>Options</h1>
+        <div class="row">
+          <div class="col-md-4">
+            <ul class="list-group">
+              <li
+                class="list-group-item d-flex justify-content-between align-items-center"
+              >
+                Publish data online
+                <div class="btn-group btn-group-toggle" data-toggle="buttons">
+                  <label class="btn btn-outline-success">
+                    <input
+                      type="radio"
+                      name="options"
+                      id="option1"
+                      autocomplete="off"
+                    />
+                    On
+                  </label>
+                  <label class="btn btn-outline-danger active">
+                    <input
+                      type="radio"
+                      name="options"
+                      id="option2"
+                      autocomplete="off"
+                      checked
+                    />
+                    Off
+                  </label>
+                </div>
+              </li>
+            </ul>
+          </div>
+        </div>
       </div>
     </div>
   </body>

--- a/client/options.ejs
+++ b/client/options.ejs
@@ -27,6 +27,7 @@
                       name="options"
                       id="option1"
                       autocomplete="off"
+                      onchange="turnOnPublishData()"
                     />
                     On
                   </label>
@@ -36,6 +37,7 @@
                       name="options"
                       id="option2"
                       autocomplete="off"
+                      onchange="turnOffPublishData()"
                       checked
                     />
                     Off
@@ -49,4 +51,6 @@
     </div>
   </body>
   <script src="/socket.io/socket.io.js"></script>
+
+  <script src="js/options.js"></script>
 </html>

--- a/client/options.ejs
+++ b/client/options.ejs
@@ -25,7 +25,7 @@
                     <input
                       type="radio"
                       name="options"
-                      id="option1"
+                      id="turnOnPublishDatabutton"
                       autocomplete="off"
                       onchange="turnOnPublishData()"
                     />
@@ -35,7 +35,7 @@
                     <input
                       type="radio"
                       name="options"
-                      id="option2"
+                      id="turnOffPublishDatabutton"
                       autocomplete="off"
                       onchange="turnOffPublishData()"
                       checked

--- a/client/options.ejs
+++ b/client/options.ejs
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <% include ./partials/head %>
+    <script src="js/jquery.min.js"></script>
+    <script src="js/bootstrap.bundle.min.js"></script>
+    <title>DAS</title>
+  </head>
+
+  <body>
+    <% include ./partials/header %> <% include ./partials/sidebar %>
+
+    <div id="main">
+      <div class="col-md-12">
+        <h1>Options</h1>
+      </div>
+    </div>
+  </body>
+  <script src="/socket.io/socket.io.js"></script>
+</html>

--- a/server/js/sockets.js
+++ b/server/js/sockets.js
@@ -15,7 +15,9 @@ function connectToPublicMQTTBroker(clientID = '') {
   const publicMqttOptions = {
     reconnectPeriod: 1000,
     connectTimeout: 5000,
-    clientId: `publicMqttClient-${clientID}`,
+    clientId: `publicMqttClient-${clientID}-${Math.random()
+      .toString(16)
+      .substr(2, 8)}`,
     username: process.env.MQTT_USERNAME,
     password: process.env.MQTT_PASSWORD,
     host: process.env.MQTT_SERVER,
@@ -202,7 +204,8 @@ sockets.init = function socketInit(server) {
       PUBLISH_ONLINE = false;
       // Disconnect from public MQTT broker
       if (PUBLIC_MQTT_CLIENT !== undefined) {
-        PUBLIC_MQTT_CLIENT.end(true);
+        PUBLIC_MQTT_CLIENT.end();
+        PUBLIC_MQTT_CLIENT = undefined;
       }
     });
 

--- a/server/server.js
+++ b/server/server.js
@@ -45,6 +45,7 @@ const sidebar = [
   { file: 'power-zone', title: 'Generate Power Map' },
   { file: 'power-calibration', title: 'Power Model Calibration' },
   { file: 'camera', title: 'Camera Settings' },
+  { file: 'options', title: 'Options' },
 ];
 
 /*


### PR DESCRIPTION
We can toggle publishing to online web server using a new Settings page now. These settings are stored on the server as variables so they are cleared everytime the server restarts. This is fine since we only turn the DAS on **once** during a testing day.

You can test this by sending test data do the your local web server, then toggling this option on the settings page and then viewing if the old dashboard updates. (https://das-dashboard.herokuapp.com/). The new online dashboard does not have the old MQTT broker connected.
![image](https://user-images.githubusercontent.com/18709969/64154735-bf265780-ce74-11e9-9a29-7041ff4ae006.png)
