### PR TITLE
Fix prop-types error on "Files" page

### DIFF
--- a/client/src/components/ContentPage.js
+++ b/client/src/components/ContentPage.js
@@ -25,7 +25,7 @@ export default function ContentPage({ title, children }) {
 
 ContentPage.propTypes = {
   title: PropTypes.string,
-  children: PropTypes.element.isRequired,
+  children: PropTypes.node.isRequired,
 };
 
 ContentPage.defaultProps = {


### PR DESCRIPTION
## Description

There is an error message logged in the console when viewing the file download page. This is to do with the runtime type checking of a component, and has no effect on the functionality.

## Screenshots

![](https://user-images.githubusercontent.com/18709969/72718857-d919ca00-3bca-11ea-90dc-4f53b65569a1.png)

## Steps to Test

Start the client and go to `/files`. There should no longer be an error in the console.
