### PR TITLE
Split camera settings into a card per camera

### DIFF
--- a/client/src/components/v2/CameraSettings.js
+++ b/client/src/components/v2/CameraSettings.js
@@ -1,0 +1,58 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import PropTypes from 'prop-types';
+import { Card } from 'react-bootstrap';
+import { useOverlays } from 'api/v2/camera';
+import RadioSelector from 'components/RadioSelector';
+
+/**
+ * @typedef {object} CameraSettingsProps
+ * @property {'primary'|'secondary'} device Camera screen
+ */
+
+/**
+ * Camera settings for a display
+ *
+ * @param {CameraSettingsProps} props Props
+ * @returns {React.Component<CameraSettingsProps>} Component
+ */
+export default function CameraSettings({ device }) {
+  const { overlays: controls, setActiveOverlay } = useOverlays(device);
+  const [selectedOverlay, setSelectedOverlay] = useState(null);
+  const name = device === 'primary' ? 'Primary' : 'Secondary';
+
+  // On overlay data load, set selected to existing value
+  useEffect(() => {
+    setSelectedOverlay(controls?.active);
+  }, [controls]);
+
+  const handleSave = useCallback((event) => {
+    event.preventDefault();
+    if (selectedOverlay) {
+      setActiveOverlay(selectedOverlay);
+    }
+  }, [selectedOverlay, setActiveOverlay]);
+
+  return (
+    <Card>
+      <Card.Body>
+        <Card.Title>{`${name} display`}</Card.Title>
+        {controls ? (
+          <RadioSelector
+            options={controls.overlays}
+            value={selectedOverlay}
+            onChange={setSelectedOverlay}
+          />
+        ) : (
+          <Card.Subtitle>Waiting for response...</Card.Subtitle>
+        )}
+      </Card.Body>
+      <Card.Footer>
+        <Card.Link href="#" onClick={handleSave}>Save</Card.Link>
+      </Card.Footer>
+    </Card>
+  );
+}
+
+CameraSettings.propTypes = {
+  device: PropTypes.string.isRequired,
+};

--- a/client/src/views/CameraSettingsView.js
+++ b/client/src/views/CameraSettingsView.js
@@ -1,12 +1,6 @@
-import React, { useState, useEffect, useCallback } from 'react';
-import {
-  Card,
-  Col,
-  Row,
-} from 'react-bootstrap';
+import React from 'react';
 import ContentPage from 'components/ContentPage';
-import RadioSelector from 'components/RadioSelector';
-import { useOverlays } from 'api/v2/camera';
+import CameraSettings from 'components/v2/CameraSettings';
 
 /**
  * Camera Settings page component
@@ -14,69 +8,14 @@ import { useOverlays } from 'api/v2/camera';
  * @returns {React.Component} Component
  */
 export default function CameraSettingsView() {
-  const { overlays: primaryControls, setActiveOverlay: setPrimaryActive } = useOverlays('primary');
-  const { overlays: secondaryControls, setActiveOverlay: setSecondaryActive } = useOverlays('secondary');
-  const [primarySelected, setPrimarySelected] = useState(null);
-  const [secondarySelected, setSecondarySelected] = useState(null);
-
-  // On overlay data load, set selected to existing value
-  useEffect(() => {
-    setPrimarySelected(primaryControls?.active);
-  }, [primaryControls]);
-  useEffect(() => {
-    setSecondarySelected(secondaryControls?.active);
-  }, [secondaryControls]);
-
-  const handleSave = useCallback((event) => {
-    event.preventDefault();
-    if (primarySelected) {
-      setPrimaryActive(primarySelected);
-    }
-    if (secondarySelected) {
-      setSecondaryActive(secondarySelected);
-    }
-  }, [primarySelected, secondarySelected, setPrimaryActive, setSecondaryActive]);
-
-  // Only render controls when overlay data is available
-  const primary = primaryControls ? (
-    <Col>
-      Primary display
-      <RadioSelector
-        options={primaryControls.overlays}
-        value={primarySelected}
-        onChange={setPrimarySelected}
-      />
-    </Col>
-  ) : null;
-
-  const secondary = secondaryControls ? (
-    <Col>
-      Secondary display
-      <RadioSelector
-        options={secondaryControls.overlays}
-        value={secondarySelected}
-        onChange={setSecondarySelected}
-      />
-    </Col>
-  ) : null;
-
   return (
     <ContentPage title="Camera Settings">
-      <Card>
-        <Card.Body>
-          <Card.Title>Camera Overlay</Card.Title>
-          {!primaryControls && !secondaryControls ? (
-            <Card.Subtitle>Waiting for response...</Card.Subtitle>
-          ) : null}
-          <Row>
-            {primary}
-            {secondary}
-          </Row>
-        </Card.Body>
-        <Card.Footer>
-          <Card.Link href="" onClick={handleSave}>Save</Card.Link>
-        </Card.Footer>
-      </Card>
+      <div className="mb-4">
+        <CameraSettings device="primary" />
+      </div>
+      <div>
+        <CameraSettings device="secondary" />
+      </div>
     </ContentPage>
   );
 }


### PR DESCRIPTION
## Description

The camera settings currently have the overlay selection for both cameras integrated into one card. This should be split into a card per camera to be better organized. This will let future features, such as messaging, be implemented with less code duplication.

## Screenshots

![image](https://user-images.githubusercontent.com/13267947/73119393-0cf14880-3f59-11ea-9e34-a99b7d4e5c44.png)

## Steps to Test

Start the camera overlay orchestrator and go to `/camera`.
