### PR TITLE
Cache packages using yarn for Github Action builds

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -7,10 +7,23 @@ jobs:
     runs-on: ubuntu-latest
     name: Run eslint
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
+
       - uses: actions/setup-node@v1
         with:
           node-version: "13.x"
+
+      - name: Get yarn cache
+        id: yarn-cache
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+
+      - uses: actions/cache@v1
+        with:
+          path: ${{ steps.yarn-cache.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
       - name: Run linter
         run: |
           cd client


### PR DESCRIPTION
## Description

<!--- What does your pull request change? What changes are expected? --->

Cache the node_modules folder so that the linting github actions does not reinstall every node package with every PR/Push.

Used this as an example: https://help.github.com/en/actions/automating-your-workflow-with-github-actions/caching-dependencies-to-speed-up-workflows

## Screenshots

<!--- Attach any screenshots relevant to your change --->

N/A

## Steps to Test

<!--- How does someone check your change? --->

Github action should be green.
