### PR TITLE
Enable CI build mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "heroku-prebuild": "cd client && yarn install && yarn build && cd .. && cd server && yarn install",
+    "heroku-prebuild": "cd client && yarn install && CI=true yarn build && cd .. && cd server && yarn install",
     "start": "cd server && yarn start"
   },
   "cacheDirectories": ["client/node_modules", "server/node_modules"],


### PR DESCRIPTION
## Description

Enable [CI build mode](https://create-react-app.dev/docs/advanced-configuration) in Create React App. This turns warnings into errors

## Screenshots

N/A

## Steps to Test

Heroku deploy should succeed
