### PR TITLE
Add controls to start and stop camera recording

### DIFF
--- a/client/src/api/v2/camera.js
+++ b/client/src/api/v2/camera.js
@@ -97,7 +97,7 @@ function parsePayload(payload) {
           {
             const mins = Math.floor(data.recordingMinutes);
             const secs = (data.recordingMinutes - mins) * 60;
-            value = `${mins} minutes ${secs} seconds`;
+            value = `${mins}m ${secs}s`;
             name = 'Recording Time';
           }
           break;

--- a/client/src/api/v2/camera.js
+++ b/client/src/api/v2/camera.js
@@ -132,7 +132,6 @@ export function useCameraRecordingStatus(device) {
   // only run init once per render
   useEffect(() => {
     initCameraStatus();
-    return () => {};
   }, []);
 
   const [lastPayload, setLastPayload] = useState(null);

--- a/client/src/api/v2/camera.js
+++ b/client/src/api/v2/camera.js
@@ -143,33 +143,23 @@ export function getInfoFromPayload(payload) {
 }
 
 /**
- * @typedef {object} StatusPayload
- * @property {string} status Status of payload
- * @property {string} payload Last payload published
- */
-
-/**
- * Returns the status of the camera and the last payload published
+ * Returns the last status payload published
  *
  * @param {string} device Device
- * @returns {StatusPayload} Status and payload
+ * @returns {string} Payload
  */
 export function useCameraRecordingStatus(device) {
   const [lastPayload, setLastPayload] = useState(getLastPayload(device));
-  const [status, setStatus] = useState(getStatusFromPayload(lastPayload) || 'Waiting for status...');
 
   const update = useCallback((newPayload) => {
     // update last payload
     storeLastPayload(device, newPayload);
     setLastPayload(newPayload);
-
-    // update status
-    setStatus(getStatusFromPayload(newPayload));
   }, [device]);
 
   useChannel(`camera-recording-status-${device}`, update);
 
-  return { status, lastPayload };
+  return lastPayload;
 }
 
 /**

--- a/client/src/api/v2/camera.js
+++ b/client/src/api/v2/camera.js
@@ -96,7 +96,7 @@ function parsePayload(payload) {
         case 'recordingMinutes':
           {
             const mins = Math.floor(data.recordingMinutes);
-            const secs = (data.recordingMinutes - mins) * 60;
+            const secs = Math.floor((data.recordingMinutes - mins) * 60);
             value = `${mins}m ${secs}s`;
             name = 'Recording Time';
           }

--- a/client/src/api/v2/camera.js
+++ b/client/src/api/v2/camera.js
@@ -143,3 +143,15 @@ export function useCameraRecordingStatus(device) {
 
   return parsePayload(lastPayload);
 }
+
+/**
+ * Makes the device name pretty.
+ *
+ * Hardcoded for efficiency. If you don't like it, complain to Angus Trau :).
+ *
+ * @param {'primary' | 'secondary'} device Device
+ * @returns {'Primary' | 'Secondary'} Prettied device name
+ */
+export function getPrettyDeviceName(device) {
+  return device === 'primary' ? 'Primary' : 'Secondary';
+}

--- a/client/src/api/v2/camera.js
+++ b/client/src/api/v2/camera.js
@@ -135,7 +135,7 @@ export function getInfoFromPayload(payload) {
         Object.keys(data)
           .filter((field) => field !== 'status')
           .map((field) => (
-            <p>{ format(field) }</p>
+            <p key={field}>{format(field)}</p>
           ))
       }
     </>

--- a/client/src/api/v2/camera.js
+++ b/client/src/api/v2/camera.js
@@ -39,3 +39,17 @@ export function useOverlays(device) {
 
   return { overlays, setActiveOverlay };
 }
+
+/**
+ * Send a message to server to start recording video
+ */
+export function startRecording() {
+  emit('start-camera-recording');
+}
+
+/**
+ * Send a message to server to stop recording video
+ */
+export function stopRecording() {
+  emit('stop-camera-recording');
+}

--- a/client/src/api/v2/camera.js
+++ b/client/src/api/v2/camera.js
@@ -141,3 +141,40 @@ export function getInfoFromPayload(payload) {
     </>
   );
 }
+
+/**
+ * @typedef {object} StatusPayload
+ * @property {string} status Status of payload
+ * @property {string} payload Last payload published
+ */
+
+/**
+ * Returns the status of the camera and the last payload published
+ *
+ * @param {string} device Device
+ * @returns {StatusPayload} Status and payload
+ */
+export function useCameraRecordingStatus(device) {
+  const [lastPayload, setLastPayload] = useState(getLastPayload(device));
+  const [status, setStatus] = useState(getStatusFromPayload(lastPayload) || 'Waiting for status...');
+
+  const update = useCallback((newPayload) => {
+    // update last payload
+    storeLastPayload(device, newPayload);
+    setLastPayload(newPayload);
+
+    // update status
+    setStatus(getStatusFromPayload(newPayload));
+  }, [device]);
+
+  useChannel(`camera-recording-status-${device}`, update);
+
+  return { status, lastPayload };
+}
+
+/**
+ * Initiate receiving camera recording statuses
+ */
+export function initCameraStatus() {
+  emit('camera-recording-init');
+}

--- a/client/src/api/v2/camera.js
+++ b/client/src/api/v2/camera.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useCallback } from 'react';
-import { startCase } from 'lodash';
 import formatBytes from 'utils/formatBytes';
+import { camelCaseToStartCase } from 'utils/string';
 import { useChannel, emit } from './socket';
 
 /**
@@ -103,7 +103,7 @@ export function getInfoFromPayload(payload) {
   if (!data) return null;
 
   const format = (field) => {
-    let name = startCase(field);
+    let name = camelCaseToStartCase(field);
     let value = '';
 
     // format field value

--- a/client/src/api/v2/camera.js
+++ b/client/src/api/v2/camera.js
@@ -152,7 +152,7 @@ export function useCameraRecordingStatus(device) {
  * Hardcoded for efficiency. If you don't like it, complain to Angus Trau :).
  *
  * @param {'primary' | 'secondary'} device Device
- * @returns {'Primary' | 'Secondary'} Prettied device name
+ * @returns {string} Prettied device name
  */
 export function getPrettyDeviceName(device) {
   return device === 'primary' ? 'Primary' : 'Secondary';

--- a/client/src/api/v2/camera.js
+++ b/client/src/api/v2/camera.js
@@ -78,7 +78,7 @@ function parsePayload(payload) {
   const data = JSON.parse(payload);
   if (!data) return null;
 
-  const fData = {};
+  const formattedData = {};
 
   Object.keys(data)
     .forEach((field) => {
@@ -109,10 +109,10 @@ function parsePayload(payload) {
           break;
       }
 
-      fData[name] = value;
+      formattedData[name] = value;
     });
 
-  return fData;
+  return formattedData;
 }
 
 /**

--- a/client/src/api/v2/camera.js
+++ b/client/src/api/v2/camera.js
@@ -75,11 +75,13 @@ export function stopRecording() {
  * @returns {CameraRecordingStatusPayload} Formatted payload without status
  */
 function parsePayload(payload) {
-  const data = typeof payload === 'string' ? JSON.parse(payload) : payload;
+  const data = JSON.parse(payload);
   if (!data) return null;
 
-  return Object.keys(data)
-    .reduce((acc, field) => {
+  const fData = {};
+
+  Object.keys(data)
+    .forEach((field) => {
       let name = camelCaseToStartCase(field);
       let value = '';
 
@@ -107,9 +109,10 @@ function parsePayload(payload) {
           break;
       }
 
-      acc[name] = value;
-      return acc;
-    }, {});
+      fData[name] = value;
+    });
+
+  return fData;
 }
 
 /**

--- a/client/src/components/v2/CameraRecording.js
+++ b/client/src/components/v2/CameraRecording.js
@@ -33,7 +33,7 @@ export default function CameraRecording({ devices }) {
               <Col
                 className={styles.topMargin}
                 key={device}
-                sm={Math.floor(12 / devices.length)}
+                sm={6}
               >
                 <Card.Subtitle>{getPrettyDeviceName(device)}</Card.Subtitle>
                 <CameraRecordingStatus device={device} />

--- a/client/src/components/v2/CameraRecording.js
+++ b/client/src/components/v2/CameraRecording.js
@@ -2,8 +2,7 @@ import React from 'react';
 import { Card } from 'react-bootstrap';
 import Button from 'react-bootstrap/Button';
 import PropTypes from 'prop-types';
-import { startRecording, stopRecording } from 'api/v2/camera';
-import { capitalise } from 'utils/string';
+import { startRecording, stopRecording, getPrettyDeviceName } from 'api/v2/camera';
 import CameraRecordingStatus from './CameraRecordingStatus';
 import styles from './CameraRecording.module.css';
 
@@ -30,7 +29,7 @@ export default function CameraRecording({ devices }) {
         {
           devices.map((device) => (
             <div key={device}>
-              <Card.Subtitle>{capitalise(device)}</Card.Subtitle>
+              <Card.Subtitle>{getPrettyDeviceName(device)}</Card.Subtitle>
               <CameraRecordingStatus device={device} />
             </div>
           ))

--- a/client/src/components/v2/CameraRecording.js
+++ b/client/src/components/v2/CameraRecording.js
@@ -27,11 +27,11 @@ export default function CameraRecording({ devices }) {
     <Card>
       <Card.Body>
         <Card.Title>Recording Controls</Card.Title>
-        <Row className={styles.topMarginContainer}>
+        <Row className={styles.row}>
           {
             devices.map((device) => (
               <Col
-                className={styles.topMargin}
+                className={styles.col}
                 key={device}
                 sm={6}
               >
@@ -42,7 +42,7 @@ export default function CameraRecording({ devices }) {
           }
         </Row>
       </Card.Body>
-      <Card.Footer className={styles.footer}>
+      <Card.Footer>
         <Button className={styles.button} variant="outline-success" onClick={startRecording}>Start</Button>
         <Button className={styles.button} variant="outline-danger" onClick={stopRecording}>Stop</Button>
       </Card.Footer>

--- a/client/src/components/v2/CameraRecording.js
+++ b/client/src/components/v2/CameraRecording.js
@@ -1,9 +1,9 @@
 import React from 'react';
 import { Card } from 'react-bootstrap';
 import Button from 'react-bootstrap/Button';
-import { emit } from 'api/v2/socket';
 import PropTypes from 'prop-types';
 import { capitalize } from 'lodash';
+import { startRecording, stopRecording } from 'api/v2/camera';
 import CameraRecordingStatus from './CameraRecordingStatus';
 
 /**
@@ -22,14 +22,6 @@ import CameraRecordingStatus from './CameraRecordingStatus';
  * @returns {React.Component<CameraRecordingProps>} Component
  */
 export default function CameraRecording({ devices }) {
-  const startRecording = () => {
-    emit('start-camera-recording');
-  };
-
-  const stopRecording = () => {
-    emit('stop-camera-recording');
-  };
-
   return (
     <Card>
       <Card.Body>

--- a/client/src/components/v2/CameraRecording.js
+++ b/client/src/components/v2/CameraRecording.js
@@ -1,6 +1,7 @@
 import React from 'react';
-import { Card } from 'react-bootstrap';
-import Button from 'react-bootstrap/Button';
+import {
+  Button, Card, Col, Row,
+} from 'react-bootstrap';
 import PropTypes from 'prop-types';
 import { startRecording, stopRecording, getPrettyDeviceName } from 'api/v2/camera';
 import CameraRecordingStatus from './CameraRecordingStatus';
@@ -26,18 +27,20 @@ export default function CameraRecording({ devices }) {
     <Card>
       <Card.Body>
         <Card.Title>Recording Controls</Card.Title>
-        {
-          devices.map((device) => (
-            <div key={device}>
-              <Card.Subtitle>{getPrettyDeviceName(device)}</Card.Subtitle>
-              <CameraRecordingStatus device={device} />
-            </div>
-          ))
-        }
+        <Row>
+          {
+            devices.map((device) => (
+              <Col key={device} sm={Math.floor(12 / devices.length)}>
+                <Card.Subtitle>{getPrettyDeviceName(device)}</Card.Subtitle>
+                <CameraRecordingStatus device={device} />
+              </Col>
+            ))
+          }
+        </Row>
       </Card.Body>
-      <Card.Footer>
-        <Button style={styles.Button} variant="outline-success" onClick={startRecording}>Start</Button>
-        <Button style={styles.Button} variant="outline-danger" onClick={stopRecording}>Stop</Button>
+      <Card.Footer className={styles.footer}>
+        <Button className={styles.button} variant="outline-success" onClick={startRecording}>Start</Button>
+        <Button className={styles.button} variant="outline-danger" onClick={stopRecording}>Stop</Button>
       </Card.Footer>
     </Card>
   );

--- a/client/src/components/v2/CameraRecording.js
+++ b/client/src/components/v2/CameraRecording.js
@@ -5,6 +5,7 @@ import PropTypes from 'prop-types';
 import { capitalize } from 'lodash';
 import { startRecording, stopRecording } from 'api/v2/camera';
 import CameraRecordingStatus from './CameraRecordingStatus';
+import styles from './CameraRecordingStatus.module.css';
 
 /**
  * @typedef {object} CameraRecordingProps
@@ -28,7 +29,7 @@ export default function CameraRecording({ devices }) {
         <Card.Title>Recording Controls</Card.Title>
         {
           devices.map((device) => (
-            <div style={{ marginBottom: '10px' }} key={device}>
+            <div styles={styles.device} key={device}>
               <Card.Subtitle>{capitalize(device)}</Card.Subtitle>
               <CameraRecordingStatus device={device} />
             </div>

--- a/client/src/components/v2/CameraRecording.js
+++ b/client/src/components/v2/CameraRecording.js
@@ -1,0 +1,34 @@
+import React from 'react';
+import { Card } from 'react-bootstrap';
+import Button from 'react-bootstrap/Button';
+
+/**
+ * Camera recording buttons for starting and stopping video recording.
+ *
+ * Starts/stops recording for both displays.
+ *
+ * @returns {React.Component} Component
+ */
+export default function CameraRecording() {
+  const startRecording = () => {
+
+  };
+
+  const stopRecording = () => {
+
+  };
+
+  return (
+    <Card>
+      <Card.Body>
+        <Card.Title>Recording Controls</Card.Title>
+        <Card.Subtitle>Recording status goes here</Card.Subtitle>
+      </Card.Body>
+      <Card.Footer>
+        <Button variant="outline-success" onClick={startRecording}>Start</Button>
+        {' '}
+        <Button variant="outline-danger" onClick={stopRecording}>Stop</Button>
+      </Card.Footer>
+    </Card>
+  );
+}

--- a/client/src/components/v2/CameraRecording.js
+++ b/client/src/components/v2/CameraRecording.js
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import { capitalize } from 'lodash';
 import { startRecording, stopRecording } from 'api/v2/camera';
 import CameraRecordingStatus from './CameraRecordingStatus';
-import styles from './CameraRecordingStatus.module.css';
+import styles from './CameraRecording.module.css';
 
 /**
  * @typedef {object} CameraRecordingProps

--- a/client/src/components/v2/CameraRecording.js
+++ b/client/src/components/v2/CameraRecording.js
@@ -1,7 +1,8 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, useState } from 'react';
 import { Card } from 'react-bootstrap';
 import Button from 'react-bootstrap/Button';
 import { emit, useChannel } from 'api/v2/socket';
+import formatBytes from 'utils/formatBytes';
 
 /**
  * Camera recording buttons for starting and stopping video recording.
@@ -13,7 +14,7 @@ import { emit, useChannel } from 'api/v2/socket';
  * @returns {React.Component} Component
  */
 export default function CameraRecording() {
-  // const [status, setStatus] = useState('Waiting for status...');
+  const [status, setStatus] = useState(<div>Waiting for status...</div>);
 
   const startRecording = () => {
     emit('start-camera-recording');
@@ -23,8 +24,47 @@ export default function CameraRecording() {
     emit('stop-camera-recording');
   };
 
-  const updateStatus = useCallback(() => {
-    console.log('status');
+  const updateStatus = useCallback((payload) => {
+    /*
+      payload structure is defined in https://www.notion.so/V3-MQTT-Topics-66e6715d0e1941ffaa82020e5868fbae
+      See /v3/camera/recording/status/<primary/>secondary>
+    */
+    const data = JSON.parse(payload);
+    let info;
+    let mins; // only used for status "recording"
+    let secs; // only used for status "recording"
+    switch (data.status) {
+      case 'off':
+        info = null;
+        break;
+
+      case 'recording':
+        mins = Math.floor(data.recordingMinutes);
+        secs = (data.recordingMinutes - mins) * 60;
+        info = (
+          <div>
+            <p>{`File Name: ${data.recordingFile}`}</p>
+            <p>{`Time: ${mins} minutes ${secs} seconds`}</p>
+          </div>
+        );
+        break;
+
+      case 'error':
+        info = <p>{data.error}</p>;
+        break;
+
+      default:
+        console.error(`Invalid recording status: ${data.status}`);
+        break;
+    }
+
+    setStatus((
+      <div>
+        <p>{`Status: ${data.status}`}</p>
+        {info}
+        <div>{`Disk Space Remaining: ${formatBytes(data.diskSpaceRemaining)}`}</div>
+      </div>
+    ));
   }, []);
 
   useChannel('camera-recording-status', updateStatus);
@@ -33,7 +73,7 @@ export default function CameraRecording() {
     <Card>
       <Card.Body>
         <Card.Title>Recording Controls</Card.Title>
-        <Card.Subtitle>status</Card.Subtitle>
+        <Card.Subtitle>{status}</Card.Subtitle>
       </Card.Body>
       <Card.Footer>
         <Button variant="outline-success" onClick={startRecording}>Start</Button>

--- a/client/src/components/v2/CameraRecording.js
+++ b/client/src/components/v2/CameraRecording.js
@@ -35,10 +35,10 @@ export default function CameraRecording({ devices }) {
         <Card.Title>Recording Controls</Card.Title>
         {
           devices.split(',').map((device) => (
-            <p>
+            <div style={{ marginBottom: '10px' }} key={device}>
               <Card.Subtitle>{device[0].toUpperCase() + device.substring(1)}</Card.Subtitle>
               <CameraRecordingStatus device={device} />
-            </p>
+            </div>
           ))
         }
       </Card.Body>

--- a/client/src/components/v2/CameraRecording.js
+++ b/client/src/components/v2/CameraRecording.js
@@ -7,7 +7,7 @@ import CameraRecordingStatus from './CameraRecordingStatus';
 
 /**
  * @typedef {object} CameraRecordingProps
- * @property {string} devices Comma separated values of devices
+ * @property {Array} devices Array of strings of device names
  */
 
 /**
@@ -34,7 +34,7 @@ export default function CameraRecording({ devices }) {
       <Card.Body>
         <Card.Title>Recording Controls</Card.Title>
         {
-          devices.split(',').map((device) => (
+          devices.map((device) => (
             <div style={{ marginBottom: '10px' }} key={device}>
               <Card.Subtitle>{device[0].toUpperCase() + device.substring(1)}</Card.Subtitle>
               <CameraRecordingStatus device={device} />
@@ -52,5 +52,5 @@ export default function CameraRecording({ devices }) {
 }
 
 CameraRecording.propTypes = {
-  devices: PropTypes.string.isRequired,
+  devices: PropTypes.arrayOf(String).isRequired,
 };

--- a/client/src/components/v2/CameraRecording.js
+++ b/client/src/components/v2/CameraRecording.js
@@ -1,28 +1,39 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import { Card } from 'react-bootstrap';
 import Button from 'react-bootstrap/Button';
+import { emit, useChannel } from 'api/v2/socket';
 
 /**
  * Camera recording buttons for starting and stopping video recording.
  *
  * Starts/stops recording for both displays.
  *
+ * This is a feature intended for V3 but is current in V2 for testing.
+ *
  * @returns {React.Component} Component
  */
 export default function CameraRecording() {
-  const startRecording = () => {
+  // const [status, setStatus] = useState('Waiting for status...');
 
+  const startRecording = () => {
+    emit('start-camera-recording');
   };
 
   const stopRecording = () => {
-
+    emit('stop-camera-recording');
   };
+
+  const updateStatus = useCallback(() => {
+    console.log('status');
+  }, []);
+
+  useChannel('camera-recording-status', updateStatus);
 
   return (
     <Card>
       <Card.Body>
         <Card.Title>Recording Controls</Card.Title>
-        <Card.Subtitle>Recording status goes here</Card.Subtitle>
+        <Card.Subtitle>status</Card.Subtitle>
       </Card.Body>
       <Card.Footer>
         <Button variant="outline-success" onClick={startRecording}>Start</Button>

--- a/client/src/components/v2/CameraRecording.js
+++ b/client/src/components/v2/CameraRecording.js
@@ -29,7 +29,7 @@ export default function CameraRecording({ devices }) {
         <Card.Title>Recording Controls</Card.Title>
         {
           devices.map((device) => (
-            <div styles={styles.device} key={device}>
+            <div key={device}>
               <Card.Subtitle>{capitalize(device)}</Card.Subtitle>
               <CameraRecordingStatus device={device} />
             </div>
@@ -37,9 +37,8 @@ export default function CameraRecording({ devices }) {
         }
       </Card.Body>
       <Card.Footer>
-        <Button variant="outline-success" onClick={startRecording}>Start</Button>
-        {' '}
-        <Button variant="outline-danger" onClick={stopRecording}>Stop</Button>
+        <Button style={styles.Button} variant="outline-success" onClick={startRecording}>Start</Button>
+        <Button style={styles.Button} variant="outline-danger" onClick={stopRecording}>Stop</Button>
       </Card.Footer>
     </Card>
   );

--- a/client/src/components/v2/CameraRecording.js
+++ b/client/src/components/v2/CameraRecording.js
@@ -3,6 +3,7 @@ import { Card } from 'react-bootstrap';
 import Button from 'react-bootstrap/Button';
 import { emit } from 'api/v2/socket';
 import PropTypes from 'prop-types';
+import { capitalize } from 'lodash';
 import CameraRecordingStatus from './CameraRecordingStatus';
 
 /**
@@ -36,7 +37,7 @@ export default function CameraRecording({ devices }) {
         {
           devices.map((device) => (
             <div style={{ marginBottom: '10px' }} key={device}>
-              <Card.Subtitle>{device[0].toUpperCase() + device.substring(1)}</Card.Subtitle>
+              <Card.Subtitle>{capitalize(device)}</Card.Subtitle>
               <CameraRecordingStatus device={device} />
             </div>
           ))

--- a/client/src/components/v2/CameraRecording.js
+++ b/client/src/components/v2/CameraRecording.js
@@ -27,10 +27,14 @@ export default function CameraRecording({ devices }) {
     <Card>
       <Card.Body>
         <Card.Title>Recording Controls</Card.Title>
-        <Row>
+        <Row className={styles.topMarginContainer}>
           {
             devices.map((device) => (
-              <Col key={device} sm={Math.floor(12 / devices.length)}>
+              <Col
+                className={styles.topMargin}
+                key={device}
+                sm={Math.floor(12 / devices.length)}
+              >
                 <Card.Subtitle>{getPrettyDeviceName(device)}</Card.Subtitle>
                 <CameraRecordingStatus device={device} />
               </Col>

--- a/client/src/components/v2/CameraRecording.js
+++ b/client/src/components/v2/CameraRecording.js
@@ -9,7 +9,7 @@ import styles from './CameraRecording.module.css';
 
 /**
  * @typedef {object} CameraRecordingProps
- * @property {Array} devices Array of strings of device names
+ * @property {string[]} devices Device names
  */
 
 /**

--- a/client/src/components/v2/CameraRecording.js
+++ b/client/src/components/v2/CameraRecording.js
@@ -2,8 +2,8 @@ import React from 'react';
 import { Card } from 'react-bootstrap';
 import Button from 'react-bootstrap/Button';
 import PropTypes from 'prop-types';
-import { capitalize } from 'lodash';
 import { startRecording, stopRecording } from 'api/v2/camera';
+import { capitalise } from 'utils/string';
 import CameraRecordingStatus from './CameraRecordingStatus';
 import styles from './CameraRecording.module.css';
 
@@ -30,7 +30,7 @@ export default function CameraRecording({ devices }) {
         {
           devices.map((device) => (
             <div key={device}>
-              <Card.Subtitle>{capitalize(device)}</Card.Subtitle>
+              <Card.Subtitle>{capitalise(device)}</Card.Subtitle>
               <CameraRecordingStatus device={device} />
             </div>
           ))

--- a/client/src/components/v2/CameraRecording.js
+++ b/client/src/components/v2/CameraRecording.js
@@ -16,7 +16,7 @@ import CameraRecordingStatus from './CameraRecordingStatus';
  *
  * Starts/stops recording for both displays.
  *
- * This is a feature intended for V3 but is current in V2 for testing.
+ * This is a feature intended for V3 but is currently in V2 for testing.
  *
  * @param {CameraRecordingProps} props Props
  * @returns {React.Component<CameraRecordingProps>} Component

--- a/client/src/components/v2/CameraRecording.module.css
+++ b/client/src/components/v2/CameraRecording.module.css
@@ -5,7 +5,7 @@
 .footer {
   display: flex;
   align-items: center;
-  justify-content: center
+  justify-content: center;
 }
 
 .topMargin {

--- a/client/src/components/v2/CameraRecording.module.css
+++ b/client/src/components/v2/CameraRecording.module.css
@@ -1,3 +1,3 @@
-.device {
-    margin-bottom: '10px'
+Button {
+    margin-right: 10px;
 }

--- a/client/src/components/v2/CameraRecording.module.css
+++ b/client/src/components/v2/CameraRecording.module.css
@@ -1,3 +1,9 @@
-Button {
-    margin-right: 10px;
+.button {
+  margin-right: 10px;
+}
+
+.footer {
+  display: flex;
+  align-items: center;
+  justify-content: center
 }

--- a/client/src/components/v2/CameraRecording.module.css
+++ b/client/src/components/v2/CameraRecording.module.css
@@ -1,0 +1,3 @@
+.device {
+    margin-bottom: '10px'
+}

--- a/client/src/components/v2/CameraRecording.module.css
+++ b/client/src/components/v2/CameraRecording.module.css
@@ -7,3 +7,11 @@
   align-items: center;
   justify-content: center
 }
+
+.topMargin {
+  margin-top: 1em;
+}
+
+.topMarginContainer {
+  margin-top: -1em;
+}

--- a/client/src/components/v2/CameraRecording.module.css
+++ b/client/src/components/v2/CameraRecording.module.css
@@ -2,16 +2,10 @@
   margin-right: 10px;
 }
 
-.footer {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-
-.topMargin {
+.col {
   margin-top: 1em;
 }
 
-.topMarginContainer {
+.row {
   margin-top: -1em;
 }

--- a/client/src/components/v2/CameraRecordingStatus.js
+++ b/client/src/components/v2/CameraRecordingStatus.js
@@ -16,9 +16,12 @@ import PropTypes from 'prop-types';
  */
 export default function CameraRecordingStatus({ device }) {
   /**
-   * Format a camera recording status payload into JSX
+   * Format a camera recording status payload into JSX.
    *
-   * @param {string} payload Payload structure is defined in https://www.notion.so/V3-MQTT-Topics-66e6715d0e1941ffaa82020e5868fbae. See /v3/camera/recording/status/<primary/>secondary>
+   * Payload structure is defined in the 'V3 MQTT Topics' page on Notion.
+   * Topic is /v3/camera/recording/status/<primary/>secondary>.
+   *
+   * @param {string} payload Payload from MQTT topic
    * @returns {React.Component} Component
    */
   function formatPayload(payload) {

--- a/client/src/components/v2/CameraRecordingStatus.js
+++ b/client/src/components/v2/CameraRecordingStatus.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { useCameraRecordingStatus } from 'api/v2/camera';
-import classNames from 'classnames';
 import styles from './CameraRecordingStatus.module.css';
 
 const defaultStatus = 'Waiting for status...';
@@ -27,7 +26,7 @@ export default function CameraRecordingStatus({ device }) {
           ? Object.keys(payload)
             .map((field) => (
               <div
-                className={classNames(styles.bottomMargin, styles.flex)}
+                className={styles.statusRow}
                 key={field}
               >
                 <span>{`${field}:`}</span>

--- a/client/src/components/v2/CameraRecordingStatus.js
+++ b/client/src/components/v2/CameraRecordingStatus.js
@@ -1,7 +1,6 @@
 import React, { useCallback, useState } from 'react';
 import { useChannel, emit } from 'api/v2/socket';
 import formatBytes from 'utils/formatBytes';
-// import { Card } from 'react-bootstrap';
 import PropTypes from 'prop-types';
 
 /**

--- a/client/src/components/v2/CameraRecordingStatus.js
+++ b/client/src/components/v2/CameraRecordingStatus.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { useCameraRecordingStatus } from 'api/v2/camera';
+import classNames from 'classnames';
 import styles from './CameraRecordingStatus.module.css';
 
 const defaultStatus = 'Waiting for status...';
@@ -26,7 +27,7 @@ export default function CameraRecordingStatus({ device }) {
           ? Object.keys(payload)
             .map((field) => (
               <div
-                className={`${styles.bottomMargin} ${styles.flex}`}
+                className={classNames(styles.bottomMargin, styles.flex)}
                 key={field}
               >
                 <span>{`${field}:`}</span>

--- a/client/src/components/v2/CameraRecordingStatus.js
+++ b/client/src/components/v2/CameraRecordingStatus.js
@@ -1,0 +1,73 @@
+import React, { useCallback, useState } from 'react';
+import { useChannel } from 'api/v2/socket';
+import formatBytes from 'utils/formatBytes';
+// import { Card } from 'react-bootstrap';
+import PropTypes from 'prop-types';
+
+/**
+ * @typedef {object} CameraRecordingStatusProps
+ * @property {'primary'|'secondary'} device Camera screen
+ */
+
+/**
+ *  Status of a camera
+ *
+ * @param {CameraRecordingStatusProps} props Props
+ * @returns {React.Component<CameraRecordingStatusProps>} Component
+ */
+export default function CameraRecordingStatus({ device }) {
+  const [status, setStatus] = useState(<div>Waiting for status...</div>);
+
+  const updateStatus = useCallback((payload) => {
+    /*
+      payload structure is defined in https://www.notion.so/V3-MQTT-Topics-66e6715d0e1941ffaa82020e5868fbae
+      See /v3/camera/recording/status/<primary/>secondary>
+    */
+    const data = JSON.parse(payload);
+    let info;
+    let mins; // only used for status "recording"
+    let secs; // only used for status "recording"
+    switch (data.status) {
+      case 'off':
+        info = null;
+        break;
+
+      case 'recording':
+        mins = Math.floor(data.recordingMinutes);
+        secs = (data.recordingMinutes - mins) * 60;
+        info = (
+          <div>
+            <p>{`File Name: ${data.recordingFile}`}</p>
+            <p>{`Time: ${mins} minutes ${secs} seconds`}</p>
+          </div>
+        );
+        break;
+
+      case 'error':
+        info = <p>{data.error}</p>;
+        break;
+
+      default:
+        console.error(`Invalid recording status: ${data.status}`);
+        break;
+    }
+
+    setStatus((
+      <div>
+        <p>{`Status: ${data.status}`}</p>
+        {info}
+        <div>{`Disk Space Remaining: ${formatBytes(data.diskSpaceRemaining)}`}</div>
+      </div>
+    ));
+  }, []);
+
+  useChannel(`camera-recording-status-${device}`, updateStatus);
+
+  return (
+    <div>{status}</div>
+  );
+}
+
+CameraRecordingStatus.propTypes = {
+  device: PropTypes.string.isRequired,
+};

--- a/client/src/components/v2/CameraRecordingStatus.js
+++ b/client/src/components/v2/CameraRecordingStatus.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { useCameraRecordingStatus } from 'api/v2/camera';
+import styles from './CameraRecordingStatus.module.css';
 
 const defaultStatus = 'Waiting for status...';
 
@@ -24,9 +25,15 @@ export default function CameraRecordingStatus({ device }) {
         payload
           ? Object.keys(payload)
             .map((field) => (
-              <p key={field}>{`${field}: ${payload[field]}`}</p>
+              <div
+                className={`${styles.bottomMargin} ${styles.flex}`}
+                key={field}
+              >
+                <span>{`${field}:`}</span>
+                <span className={styles.push}>{payload[field]}</span>
+              </div>
             ))
-          : <p>{`Status: ${defaultStatus}`}</p>
+          : <div className={styles.p}>{`Status: ${defaultStatus}`}</div>
       }
     </div>
   );

--- a/client/src/components/v2/CameraRecordingStatus.js
+++ b/client/src/components/v2/CameraRecordingStatus.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {
-  getInfoFromPayload, useCameraRecordingStatus, initCameraStatus, getStatusFromPayload,
+  useCameraRecordingStatus, initCameraStatus, formatPayload,
 } from 'api/v2/camera';
 
 const defaultStatus = 'Waiting for status...';
@@ -18,14 +18,22 @@ const defaultStatus = 'Waiting for status...';
  * @returns {React.Component<CameraRecordingStatusProps>} Component
  */
 export default function CameraRecordingStatus({ device }) {
-  const lastPayload = useCameraRecordingStatus(device);
-
   initCameraStatus();
+
+  const fPayload = formatPayload(useCameraRecordingStatus(device));
+
+  console.log(fPayload);
 
   return (
     <div>
-      <p>{`Status: ${getStatusFromPayload(lastPayload) || defaultStatus}`}</p>
-      {getInfoFromPayload(lastPayload)}
+      {
+        fPayload
+          ? Object.keys(fPayload)
+            .map((field) => (
+              <p key={field}>{`${field}: ${fPayload[field]}`}</p>
+            ))
+          : <p>{`Status: ${defaultStatus}`}</p>
+      }
     </div>
   );
 }

--- a/client/src/components/v2/CameraRecordingStatus.js
+++ b/client/src/components/v2/CameraRecordingStatus.js
@@ -1,8 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import {
-  useCameraRecordingStatus, initCameraStatus, formatPayload,
-} from 'api/v2/camera';
+import { useCameraRecordingStatus } from 'api/v2/camera';
 
 const defaultStatus = 'Waiting for status...';
 
@@ -18,19 +16,15 @@ const defaultStatus = 'Waiting for status...';
  * @returns {React.Component<CameraRecordingStatusProps>} Component
  */
 export default function CameraRecordingStatus({ device }) {
-  initCameraStatus();
-
-  const fPayload = formatPayload(useCameraRecordingStatus(device));
-
-  console.log(fPayload);
+  const payload = useCameraRecordingStatus(device);
 
   return (
     <div>
       {
-        fPayload
-          ? Object.keys(fPayload)
+        payload
+          ? Object.keys(payload)
             .map((field) => (
-              <p key={field}>{`${field}: ${fPayload[field]}`}</p>
+              <p key={field}>{`${field}: ${payload[field]}`}</p>
             ))
           : <p>{`Status: ${defaultStatus}`}</p>
       }

--- a/client/src/components/v2/CameraRecordingStatus.js
+++ b/client/src/components/v2/CameraRecordingStatus.js
@@ -1,9 +1,6 @@
-import React, { useCallback, useState } from 'react';
-import { useChannel, emit } from 'api/v2/socket';
+import React from 'react';
 import PropTypes from 'prop-types';
-import {
-  getLastPayload, storeLastPayload, getStatusFromPayload, getInfoFromPayload,
-} from 'api/v2/camera';
+import { getInfoFromPayload, useCameraRecordingStatus, initCameraStatus } from 'api/v2/camera';
 
 /**
  * @typedef {object} CameraRecordingStatusProps
@@ -17,21 +14,9 @@ import {
  * @returns {React.Component<CameraRecordingStatusProps>} Component
  */
 export default function CameraRecordingStatus({ device }) {
-  const [lastPayload, setLastPayload] = useState(getLastPayload(device));
-  const [status, setStatus] = useState(getStatusFromPayload(lastPayload) || 'Waiting for status...');
+  const { status, lastPayload } = useCameraRecordingStatus(device);
 
-  const update = useCallback((payload) => {
-    // update last payload
-    storeLastPayload(device, payload);
-    setLastPayload(payload);
-
-    // update status
-    setStatus(getStatusFromPayload(payload));
-  }, [device]);
-
-  useChannel(`camera-recording-status-${device}`, update);
-
-  emit('camera-recording-init');
+  initCameraStatus();
 
   return (
     <div>

--- a/client/src/components/v2/CameraRecordingStatus.js
+++ b/client/src/components/v2/CameraRecordingStatus.js
@@ -20,11 +20,7 @@ export default function CameraRecordingStatus({ device }) {
 
   return (
     <div>
-      <p>
-        Status:
-        {' '}
-        {status}
-      </p>
+      <p>{`Status: ${status}`}</p>
       {getInfoFromPayload(lastPayload)}
     </div>
   );

--- a/client/src/components/v2/CameraRecordingStatus.js
+++ b/client/src/components/v2/CameraRecordingStatus.js
@@ -25,9 +25,7 @@ export default function CameraRecordingStatus({ device }) {
         {' '}
         {status}
       </p>
-      <div>
-        <p>{getInfoFromPayload(lastPayload)}</p>
-      </div>
+      {getInfoFromPayload(lastPayload)}
     </div>
   );
 }

--- a/client/src/components/v2/CameraRecordingStatus.js
+++ b/client/src/components/v2/CameraRecordingStatus.js
@@ -1,7 +1,9 @@
 import React, { useCallback, useState } from 'react';
 import { useChannel, emit } from 'api/v2/socket';
-import formatBytes from 'utils/formatBytes';
 import PropTypes from 'prop-types';
+import {
+  getLastPayload, storeLastPayload, getStatusFromPayload, getInfoFromPayload,
+} from 'api/v2/camera';
 
 /**
  * @typedef {object} CameraRecordingStatusProps
@@ -15,78 +17,33 @@ import PropTypes from 'prop-types';
  * @returns {React.Component<CameraRecordingStatusProps>} Component
  */
 export default function CameraRecordingStatus({ device }) {
-  /**
-   * Format a camera recording status payload into JSX.
-   *
-   * Payload structure is defined in the 'V3 MQTT Topics' page on Notion.
-   * Topic is /v3/camera/recording/status/<primary/>secondary>.
-   *
-   * @param {string} payload Payload from MQTT topic
-   * @returns {React.Component} Component
-   */
-  function formatPayload(payload) {
-    const data = JSON.parse(payload);
-    if (!data) return null;
+  const [lastPayload, setLastPayload] = useState(getLastPayload(device));
+  const [status, setStatus] = useState(getStatusFromPayload(lastPayload) || 'Waiting for status...');
 
-    let info;
-    let mins; // only used for status "recording"
-    let secs; // only used for status "recording"
-    switch (data.status) {
-      case 'off':
-        info = null;
-        break;
+  const update = useCallback((payload) => {
+    // update last payload
+    storeLastPayload(device, payload);
+    setLastPayload(payload);
 
-      case 'recording':
-        mins = Math.floor(data.recordingMinutes);
-        secs = (data.recordingMinutes - mins) * 60;
-        info = (
-          <div>
-            <p>{`File Name: ${data.recordingFile}`}</p>
-            <p>{`Time: ${mins} minutes ${secs} seconds`}</p>
-          </div>
-        );
-        break;
-
-      case 'error':
-        info = <p>{data.error}</p>;
-        break;
-
-      default:
-        console.error(`Invalid recording status: ${data.status}`);
-        break;
-    }
-
-    return (
-      <div>
-        <p>{`Status: ${data.status}`}</p>
-        {info}
-        <div>{`Disk Space Remaining: ${formatBytes(data.diskSpaceRemaining)}`}</div>
-      </div>
-    );
-  }
-
-  const lastPayload = sessionStorage.getItem(`camera-recording-last-payload-${device}`);
-  const [status, setStatus] = useState((
-    <div>
-      {
-        lastPayload ? formatPayload(lastPayload) : 'Waiting for status...'
-      }
-    </div>
-  ));
-
-  const updateStatus = useCallback((payload) => {
-    // store payload for session
-    sessionStorage.setItem(`camera-recording-last-payload-${device}`, payload);
-
-    setStatus(formatPayload(payload));
+    // update status
+    setStatus(getStatusFromPayload(payload));
   }, [device]);
 
-  useChannel(`camera-recording-status-${device}`, updateStatus);
+  useChannel(`camera-recording-status-${device}`, update);
 
   emit('camera-recording-init');
 
   return (
-    <div>{status}</div>
+    <div>
+      <p>
+        Status:
+        {' '}
+        {status}
+      </p>
+      <div>
+        <p>{getInfoFromPayload(lastPayload)}</p>
+      </div>
+    </div>
   );
 }
 

--- a/client/src/components/v2/CameraRecordingStatus.js
+++ b/client/src/components/v2/CameraRecordingStatus.js
@@ -1,6 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { getInfoFromPayload, useCameraRecordingStatus, initCameraStatus } from 'api/v2/camera';
+import {
+  getInfoFromPayload, useCameraRecordingStatus, initCameraStatus, getStatusFromPayload,
+} from 'api/v2/camera';
+
+const defaultStatus = 'Waiting for status...';
 
 /**
  * @typedef {object} CameraRecordingStatusProps
@@ -14,13 +18,13 @@ import { getInfoFromPayload, useCameraRecordingStatus, initCameraStatus } from '
  * @returns {React.Component<CameraRecordingStatusProps>} Component
  */
 export default function CameraRecordingStatus({ device }) {
-  const { status, lastPayload } = useCameraRecordingStatus(device);
+  const lastPayload = useCameraRecordingStatus(device);
 
   initCameraStatus();
 
   return (
     <div>
-      <p>{`Status: ${status}`}</p>
+      <p>{`Status: ${getStatusFromPayload(lastPayload) || defaultStatus}`}</p>
       {getInfoFromPayload(lastPayload)}
     </div>
   );

--- a/client/src/components/v2/CameraRecordingStatus.module.css
+++ b/client/src/components/v2/CameraRecordingStatus.module.css
@@ -1,8 +1,5 @@
-.bottomMargin {
+.statusRow {
     margin-bottom: 0.3em;
-}
-
-.flex {
     display: flex;
 }
 

--- a/client/src/components/v2/CameraRecordingStatus.module.css
+++ b/client/src/components/v2/CameraRecordingStatus.module.css
@@ -1,0 +1,11 @@
+.bottomMargin {
+    margin-bottom: 0.3em;
+}
+
+.flex {
+    display: flex;
+}
+
+.push {
+    margin-left: auto;
+}

--- a/client/src/components/v2/CameraSettings.js
+++ b/client/src/components/v2/CameraSettings.js
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import PropTypes from 'prop-types';
 import { Card } from 'react-bootstrap';
-import { useOverlays } from 'api/v2/camera';
+import { useOverlays, getPrettyDeviceName } from 'api/v2/camera';
 import RadioSelector from 'components/RadioSelector';
 
 /**
@@ -18,7 +18,7 @@ import RadioSelector from 'components/RadioSelector';
 export default function CameraSettings({ device }) {
   const { overlays: controls, setActiveOverlay } = useOverlays(device);
   const [selectedOverlay, setSelectedOverlay] = useState(null);
-  const name = device === 'primary' ? 'Primary' : 'Secondary';
+  const name = getPrettyDeviceName(device);
 
   // On overlay data load, set selected to existing value
   useEffect(() => {

--- a/client/src/utils/formatBytes.js
+++ b/client/src/utils/formatBytes.js
@@ -1,6 +1,8 @@
 /**
  * Converts number of bytes to a more human readable unit.
  *
+ * By StackOverflow's community https://stackoverflow.com/questions/15900485/correct-way-to-convert-size-in-bytes-to-kb-mb-gb-in-javascript
+ *
  * @param {number} bytes -- Number of bytes
  * @param {number} digits -- Number of decimal places to round to
  * @returns {string} bytes represented in a format with units

--- a/client/src/utils/formatBytes.js
+++ b/client/src/utils/formatBytes.js
@@ -1,0 +1,14 @@
+/**
+ * Converts number of bytes to a more human readable unit.
+ *
+ * @param {number} bytes -- Number of bytes
+ * @param {number} digits -- Number of decimal places to round to
+ * @returns {string} bytes represented in a format with units
+ */
+export default function formatBytes(bytes, digits = 2) {
+  if (bytes === 0) return '0 Bytes';
+  const units = ['Bytes', 'KiB', 'MiB', 'GiB', 'TiB', 'PiB', 'EiB', 'ZiB', 'YiB'];
+  const d = digits < 0 ? 0 : digits;
+  const mag = Math.floor(Math.log(bytes) / Math.log(1024));
+  return `${parseFloat((bytes / (1024 ** mag)).toFixed(d))} ${units[mag]}`;
+}

--- a/client/src/utils/string.js
+++ b/client/src/utils/string.js
@@ -1,0 +1,20 @@
+/**
+ * Capitalise a string
+ *
+ * @param {string} string String to capitalise
+ * @returns {string} Capitalised string
+ */
+export function capitalise(string) {
+  return string.charAt(0).toUpperCase() + string.slice(1);
+}
+
+/**
+ * Convert a camel cased string ('fooBar') to start case ('Foo Bar')
+ *
+ * @param {string} string String to convert
+ * @returns {string} Start case string
+ */
+export function camelCaseToStartCase(string) {
+  const split = string.replace(/([A-Z])/g, ' $1');
+  return capitalise(split);
+}

--- a/client/src/views/v2/CameraSettingsView.js
+++ b/client/src/views/v2/CameraSettingsView.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import ContentPage from 'components/ContentPage';
 import CameraSettings from 'components/v2/CameraSettings';
+import CameraRecording from 'components/v2/CameraRecording';
 
 /**
  * Camera Settings page component
@@ -10,6 +11,9 @@ import CameraSettings from 'components/v2/CameraSettings';
 export default function CameraSettingsView() {
   return (
     <ContentPage title="Camera Settings">
+      <div className="mb-4">
+        <CameraRecording />
+      </div>
       <div className="mb-4">
         <CameraSettings device="primary" />
       </div>

--- a/client/src/views/v2/CameraSettingsView.js
+++ b/client/src/views/v2/CameraSettingsView.js
@@ -12,7 +12,7 @@ export default function CameraSettingsView() {
   return (
     <ContentPage title="Camera Settings">
       <div className="mb-4">
-        <CameraRecording />
+        <CameraRecording devices="primary,secondary" />
       </div>
       <div className="mb-4">
         <CameraSettings device="primary" />

--- a/client/src/views/v2/CameraSettingsView.js
+++ b/client/src/views/v2/CameraSettingsView.js
@@ -12,7 +12,7 @@ export default function CameraSettingsView() {
   return (
     <ContentPage title="Camera Settings">
       <div className="mb-4">
-        <CameraRecording devices="primary,secondary" />
+        <CameraRecording devices={['primary', 'secondary']} />
       </div>
       <div className="mb-4">
         <CameraSettings device="primary" />

--- a/server/js/sockets.js
+++ b/server/js/sockets.js
@@ -152,10 +152,12 @@ sockets.init = function socketInit(server) {
             break;
         }
       } else if (
-        topic === '/v3/camera/recording/status/primary' ||
-        topic === '/v3/camera/recording/status/secondary'
+        topicString.slice(0, -1).join('/') === '/v3/camera/recording/status'
       ) {
-        socket.emit('camera-recording-status', payloadString);
+        socket.emit(
+          `camera-recording-status-${topicString[topicString.length - 1]}`,
+          payloadString,
+        );
       } else {
         console.error(`Unhandled topic - ${topic}`);
       }

--- a/server/js/sockets.js
+++ b/server/js/sockets.js
@@ -91,6 +91,8 @@ sockets.init = function socketInit(server) {
   mqttClient.subscribe('power_model/recommended_SP');
   mqttClient.subscribe('power_model/plan_generated');
   mqttClient.subscribe('camera/push_overlays');
+  mqttClient.subscribe('/v3/camera/recording/status/primary');
+  mqttClient.subscribe('/v3/camera/recording/status/secondary');
   mqttClient.on('connect', mqttConnected);
   mqttClient.on('error', mqttError);
   // Not a heroku instance
@@ -149,6 +151,12 @@ sockets.init = function socketInit(server) {
             console.error(`Unhandled topic - ${topic}`);
             break;
         }
+      } else if (
+        topic === '/v3/camera/recording/status/primary' ||
+        topic === '/v3/camera/recording/status/secondary'
+      ) {
+        console.log(`emit status ${payloadString}`);
+        socket.emit('camera-recording-status');
       } else {
         console.error(`Unhandled topic - ${topic}`);
       }
@@ -211,6 +219,14 @@ sockets.init = function socketInit(server) {
 
     socket.on('get-server-settings', () => {
       socket.emit('server-settings', { publishOnline: PUBLISH_ONLINE });
+    });
+
+    socket.on('start-camera-recording', () => {
+      mqttClient.publish('/v3/camera/recording/start');
+    });
+
+    socket.on('stop-camera-recording', () => {
+      mqttClient.publish('/v3/camera/recording/stop');
     });
   });
 };

--- a/server/js/sockets.js
+++ b/server/js/sockets.js
@@ -91,7 +91,7 @@ sockets.init = function socketInit(server) {
   mqttClient.subscribe('power_model/recommended_SP');
   mqttClient.subscribe('power_model/plan_generated');
   mqttClient.subscribe('camera/push_overlays');
-  // camera recording status subscription occurs when 'camera-recording-init' is received
+  // Camera recording status subscription occurs when 'camera-recording-init' is received
   mqttClient.on('connect', mqttConnected);
   mqttClient.on('error', mqttError);
   // Not a heroku instance
@@ -153,7 +153,7 @@ sockets.init = function socketInit(server) {
       } else if (
         topicString.slice(0, -1).join('/') === '/v3/camera/recording/status'
       ) {
-        // send mqtt payload on corresponding channel
+        // Send mqtt payload on corresponding channel
         socket.emit(
           `camera-recording-status-${topicString[topicString.length - 1]}`,
           payloadString,

--- a/server/js/sockets.js
+++ b/server/js/sockets.js
@@ -155,8 +155,7 @@ sockets.init = function socketInit(server) {
         topic === '/v3/camera/recording/status/primary' ||
         topic === '/v3/camera/recording/status/secondary'
       ) {
-        console.log(`emit status ${payloadString}`);
-        socket.emit('camera-recording-status');
+        socket.emit('camera-recording-status', payloadString);
       } else {
         console.error(`Unhandled topic - ${topic}`);
       }

--- a/server/js/sockets.js
+++ b/server/js/sockets.js
@@ -91,8 +91,7 @@ sockets.init = function socketInit(server) {
   mqttClient.subscribe('power_model/recommended_SP');
   mqttClient.subscribe('power_model/plan_generated');
   mqttClient.subscribe('camera/push_overlays');
-  mqttClient.subscribe('/v3/camera/recording/status/primary');
-  mqttClient.subscribe('/v3/camera/recording/status/secondary');
+  // camera recording status subscription occurs when 'camera-recording-init' is received
   mqttClient.on('connect', mqttConnected);
   mqttClient.on('error', mqttError);
   // Not a heroku instance
@@ -154,6 +153,7 @@ sockets.init = function socketInit(server) {
       } else if (
         topicString.slice(0, -1).join('/') === '/v3/camera/recording/status'
       ) {
+        // send mqtt payload on corresponding channel
         socket.emit(
           `camera-recording-status-${topicString[topicString.length - 1]}`,
           payloadString,
@@ -220,6 +220,11 @@ sockets.init = function socketInit(server) {
 
     socket.on('get-server-settings', () => {
       socket.emit('server-settings', { publishOnline: PUBLISH_ONLINE });
+    });
+
+    socket.on('camera-recording-init', () => {
+      mqttClient.subscribe('/v3/camera/recording/status/primary');
+      mqttClient.subscribe('/v3/camera/recording/status/secondary');
     });
 
     socket.on('start-camera-recording', () => {


### PR DESCRIPTION
## Description

Add Start and Stop recording buttons to publish start (`/v3/camera/recording/start)` and stop (`/v3/camera/recording/stop`) topics for starting and stopping a camera's recording. Also includes status displays for both cameras.

Initally displays the last received payload from `/v3/camera/recording/status/<primary/secondary>` if it exists.

## Screenshots

![off](https://user-images.githubusercontent.com/50545432/88550872-87646780-d065-11ea-9beb-02290b2fc3ab.png)

![recording](https://user-images.githubusercontent.com/50545432/88550936-99460a80-d065-11ea-912b-33993092ed2b.png)

![error](https://user-images.githubusercontent.com/50545432/88551055-be3a7d80-d065-11ea-9249-f28f697cd9cd.png)

## Steps to Test

Start `mosquitto` broker

Start [raspicam](https://github.com/monash-human-power/raspicam) with `python overlay_new.py` (or any over really)

Start [server](../server) and [client](../client)

### Tests

- Wait for raspicam to automatically publish
- Run `mosquitto_pub -t /v3/camera/recording/status/primary -m "{\"status\":\"recording\", \"recordingMinutes\": 10.50, \"recordingFile\": \"test.mp4\", \"diskSpaceRemaining\": 100000000000}"` 