### PR TITLE
Add Indicator component

### DIFF
--- a/client/.eslintrc
+++ b/client/.eslintrc
@@ -20,6 +20,7 @@
     ],
     "jsx-a11y/anchor-is-valid": "off",
     "import/no-unresolved": "off",
-    "import/prefer-default-export": "off"
+    "import/prefer-default-export": "off",
+    "semi": "error"
   }
 }

--- a/client/src/components/v2/Indicator.js
+++ b/client/src/components/v2/Indicator.js
@@ -1,0 +1,24 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import { Badge } from "react-bootstrap";
+
+/**
+ * @typedef {object} IndicatorProps
+ * @property {string}           variant     Variant of indicator
+ * @property {React.ReactNode}  children  Children
+ */
+
+/**
+ * General indicator
+ *
+ * @param {IndicatorProps} props Props
+ * @returns {React.Component<IndicatorProps>} Component
+ */
+export default function Indicator({ variant, children }) {
+    return <Badge pill variant={variant}>{children}</Badge>;
+};
+
+Indicator.propTypes = {
+    variant: PropTypes.string.isRequired,
+    children: PropTypes.node.isRequired
+};

--- a/client/src/components/v2/OnlineIndicator.js
+++ b/client/src/components/v2/OnlineIndicator.js
@@ -5,6 +5,8 @@ import Indicator from './Indicator';
 /**
  * @typedef {object} OnlineIndicatorProps
  * @property {string}           online State of the indicator
+ * @property {?string}          on Text to display for "online" status
+ * @property {?string}          off Text to display for "offline" status
  */
 
 /**
@@ -13,14 +15,21 @@ import Indicator from './Indicator';
  * @param {OnlineIndicatorProps} props Props
  * @returns {React.Component<OnlineIndicatorProps>} Component
  */
-export default function OnlineIndicator({ online }) {
+export default function OnlineIndicator({ online, on, off }) {
     return (
         <Indicator variant={online ? 'success' : 'danger'}>
-            {online ? 'ON' : 'OFF'}
+            {online ? on : off}
         </Indicator>
     );
 }
 
+OnlineIndicator.defaultProps = {
+    on: 'ON',
+    off: 'OFF'
+};
+
 OnlineIndicator.propTypes = {
-    online: PropTypes.bool.isRequired
+    online: PropTypes.bool.isRequired,
+    on: PropTypes.string,
+    off: PropTypes.string
 };

--- a/client/src/components/v2/OnlineIndicator.js
+++ b/client/src/components/v2/OnlineIndicator.js
@@ -1,0 +1,26 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import Indicator from './Indicator';
+
+/**
+ * @typedef {object} OnlineIndicatorProps
+ * @property {string}           online State of the indicator
+ */
+
+/**
+ * Indicator for Online / Offline
+ *
+ * @param {OnlineIndicatorProps} props Props
+ * @returns {React.Component<OnlineIndicatorProps>} Component
+ */
+export default function OnlineIndicator({ online }) {
+    return (
+        <Indicator variant={online ? 'success' : 'danger'}>
+            {online ? 'ON' : 'OFF'}
+        </Indicator>
+    );
+}
+
+OnlineIndicator.propTypes = {
+    online: PropTypes.bool.isRequired
+};

--- a/client/src/views/v2/SensorStatusView.js
+++ b/client/src/views/v2/SensorStatusView.js
@@ -1,8 +1,9 @@
-import React from 'react';
-import { Badge, ListGroup } from 'react-bootstrap';
-import ContentPage from 'components/ContentPage';
-import WidgetListGroupItem from 'components/WidgetListGroupItem';
 import { useStatus } from 'api/v2/sensors';
+import ContentPage from 'components/ContentPage';
+import OnlineIndicator from 'components/v2/OnlineIndicator';
+import WidgetListGroupItem from 'components/WidgetListGroupItem';
+import React from 'react';
+import { ListGroup } from 'react-bootstrap';
 
 /**
  * Sensor Status page component
@@ -14,9 +15,7 @@ export default function SensorStatusView() {
 
   const sensorItems = sensorStatus.map(({ label, name, state }) => (
     <WidgetListGroupItem title={label} key={name}>
-      <Badge pill variant={state ? 'success' : 'danger'}>
-        {state ? 'ON' : 'OFF'}
-      </Badge>
+      <OnlineIndicator online={state} />
     </WidgetListGroupItem>
   ));
 


### PR DESCRIPTION
## Description

`Indicator` uses `Badge` to create a component that can be used to represent the state of something (e.g. online, offline, recording). Currently, the only place where this is used is in the Sensor Status page (as `OnlineIndicator`); however, we may want to add indicators on other pages (such as Camera Settings) so this will reduce repeated code and aid in understandability (by abstracting explicitly declared `Badge`s as an `Indicator`).

## Steps to Test

1. Start `DAShboard` client and server

2. Navigate to `/v2/status`

3. It looks the same as before
