### PR TITLE
Refactoring status message processing, storage, and sending/receiving

### DIFF
--- a/client/src/api/v2/camera.js
+++ b/client/src/api/v2/camera.js
@@ -123,10 +123,13 @@ function parseRecordingPayloadData(data) {
 }
 
 /**
- * Initiate receiving camera recording statuses
+ * Initiate receiving status payloads
+ *
+ * @param {string} subComponent The sub component to init for (e.g. recording, video feed)
  */
-function initCameraStatus() {
-  emit('send-camera-recording-payloads');
+function initStatus(subComponent) {
+  console.log(`emit status-camera-${subComponent}`)
+  emit(`status-camera-${subComponent}`);
 }
 
 /**
@@ -138,7 +141,7 @@ function initCameraStatus() {
 export function useCameraRecordingStatus(device) {
   // Only run init once per render
   useEffect(() => {
-    initCameraStatus();
+    initStatus("recording");
   }, []);
 
   const [lastPayload, setLastPayload] = useState(null);
@@ -146,11 +149,14 @@ export function useCameraRecordingStatus(device) {
   const update = useCallback((newPayload) => {
     // Update last payload
     setLastPayload(newPayload);
+    console.log(`receive ${`status-camera-recording`}: ${JSON.stringify(newPayload)}`)
   }, []);
 
-  useChannel(`camera-recording-status-${device}`, update);
+  useChannel(`status-camera-recording`, update);
 
-  return parseRecordingPayloadData(lastPayload);
+
+  console.log(`parsed: ${JSON.stringify(lastPayload)}`);
+  return parseRecordingPayloadData(lastPayload && lastPayload[device]);
 }
 
 /**
@@ -166,13 +172,6 @@ export function getPrettyDeviceName(device) {
 }
 
 /**
- * Initiate receiving camera video feed statuses
- */
-function initVideoFeedStatus() {
-  emit('send-video-feed-payloads');
-}
-
-/**
  * @typedef {object} VideoFeedStatus
  * @property {boolean}  online Whether video feed is on/off
  */
@@ -185,16 +184,17 @@ function initVideoFeedStatus() {
 export function useVideoFeedStatus() {
   // Only run init once per render
   useEffect(() => {
-    initVideoFeedStatus();
+    initStatus('video-feed');
   }, []);
 
-  const [payloads, setPayloads] = useState({}); // Payloads is Object.<string, string payload>
+  const [payload, setPayloads] = useState({}); // Payloads is Object.<string, string payload>
 
-  const handler = useCallback((newPayloads) => {
-    setPayloads(newPayloads);
+  const handler = useCallback((newPayload) => {
+    setPayloads(newPayload);
+    console.log(`receive ${`status-camera-video-feed`}: ${JSON.stringify(newPayload)}`)
   }, []);
 
-  useChannel(`camera-video-feed-status`, handler);
+  useChannel(`status-camera-video-feed`, handler);
 
-  return payloads;
+  return payload;
 }

--- a/client/src/api/v2/camera.js
+++ b/client/src/api/v2/camera.js
@@ -128,7 +128,6 @@ function parseRecordingPayloadData(data) {
  * @param {string} subComponent The sub component to init for (e.g. recording, video feed)
  */
 function initStatus(subComponent) {
-  console.log(`emit status-camera-${subComponent}`)
   emit(`status-camera-${subComponent}`);
 }
 
@@ -149,13 +148,10 @@ export function useCameraRecordingStatus(device) {
   const update = useCallback((newPayload) => {
     // Update last payload
     setLastPayload(newPayload);
-    console.log(`receive ${`status-camera-recording`}: ${JSON.stringify(newPayload)}`)
   }, []);
 
   useChannel(`status-camera-recording`, update);
 
-
-  console.log(`parsed: ${JSON.stringify(lastPayload)}`);
   return parseRecordingPayloadData(lastPayload && lastPayload[device]);
 }
 
@@ -191,7 +187,6 @@ export function useVideoFeedStatus() {
 
   const handler = useCallback((newPayload) => {
     setPayloads(newPayload);
-    console.log(`receive ${`status-camera-video-feed`}: ${JSON.stringify(newPayload)}`)
   }, []);
 
   useChannel(`status-camera-video-feed`, handler);

--- a/client/src/components/v2/CameraRecordingStatus.module.css
+++ b/client/src/components/v2/CameraRecordingStatus.module.css
@@ -5,4 +5,5 @@
 
 .push {
   margin-left: auto;
+  text-align: right;
 }

--- a/server/js/sockets.js
+++ b/server/js/sockets.js
@@ -176,7 +176,6 @@ sockets.init = function socketInit(server) {
         }
       } else if (topic.match(/^\/v3\/status/)) {
         // topicString: ["", "v3", "status", "<component>", "<subcomponent>", "<device>"]
-        console.log(`mqtt ${topic}: ${payloadString}`);
         const component = topicString[3];
         const subComponent = topicString[4];
         const device = topicString[5];
@@ -262,12 +261,6 @@ sockets.init = function socketInit(server) {
           socket.emit(
             `status-${component}-${subComponent}`,
             global.statusPayloads[component][subComponent],
-          );
-
-          console.log(
-            `emit: status-${component}-${subComponent}: ${JSON.stringify(
-              global.statusPayloads[component][subComponent],
-            )}`,
           );
         });
       });

--- a/server/js/sockets.js
+++ b/server/js/sockets.js
@@ -12,8 +12,18 @@ let PUBLISH_ONLINE = false;
 let PUBLIC_MQTT_CLIENT;
 
 // global vars
-global.lastRecordingPayloads = {};
-global.lastVideoFeedPayloads = {};
+global.statusPayloads = {
+  camera: {
+    'video-feed': {
+      primary: {},
+      secondary: {},
+    },
+    recording: {
+      primary: {},
+      secondary: {},
+    },
+  },
+};
 
 function connectToPublicMQTTBroker(clientID = '') {
   const publicMqttOptions = {
@@ -115,8 +125,7 @@ sockets.init = function socketInit(server) {
         Subscribe with the other topics and add a new message handler
         for the topics
     */
-    mqttClient.subscribe('/v3/camera/recording/status/+');
-    mqttClient.subscribe('/v3/camera/video-feed/status/+');
+    mqttClient.subscribe('/v3/status/#');
 
     mqttClient.on('message', function mqttMessage(topic, payload) {
       const payloadString = payload.toString();
@@ -165,29 +174,22 @@ sockets.init = function socketInit(server) {
             console.error(`Unhandled topic - ${topic}`);
             break;
         }
-      } else if (
-        topicString.slice(0, -1).join('/') === '/v3/camera/recording/status'
-      ) {
-        const deviceName = topicString[topicString.length - 1];
-
+      } else if (topic.match(/^\/v3\/status/)) {
+        // topicString: ["", "v3", "status", "<component>", "<subcomponent>", "<device>"]
+        console.log(`mqtt ${topic}: ${payloadString}`);
+        const component = topicString[3];
+        const subComponent = topicString[4];
+        const device = topicString[5];
         // Store last received payload for device globally
-        global.lastRecordingPayloads[deviceName] = JSON.parse(payloadString);
+        global.statusPayloads[component][subComponent][device] = JSON.parse(
+          payloadString,
+        );
 
         // Send mqtt payload on corresponding channel
         socket.emit(
-          `camera-recording-status-${deviceName}`,
-          global.lastRecordingPayloads[deviceName],
+          `status-${component}-${subComponent}`,
+          global.statusPayloads[component][subComponent],
         );
-      } else if (
-        topicString.slice(0, -1).join('/') === '/v3/camera/video-feed/status'
-      ) {
-        // Store last received payload for device globally
-        global.lastVideoFeedPayloads[
-          topicString[topicString.length - 1]
-        ] = JSON.parse(payloadString);
-
-        // Send mqtt payload on corresponding channel
-        socket.emit(`camera-video-feed-status`, global.lastVideoFeedPayloads);
       } else {
         console.error(`Unhandled topic - ${topic}`);
       }
@@ -252,18 +254,23 @@ sockets.init = function socketInit(server) {
       socket.emit('server-settings', { publishOnline: PUBLISH_ONLINE });
     });
 
-    socket.on('send-camera-recording-payloads', () => {
-      // Send mqtt payload on corresponding channel for each device
-      Object.keys(global.lastRecordingPayloads).forEach((device) => {
-        socket.emit(
-          `camera-recording-status-${device}`,
-          global.lastRecordingPayloads[device],
-        );
-      });
-    });
+    // Create a socket channel for each sub component (e.g. recording, video feed)
+    Object.keys(global.statusPayloads).forEach((component) => {
+      Object.keys(global.statusPayloads[component]).forEach((subComponent) => {
+        socket.on(`status-${component}-${subComponent}`, () => {
+          // Send mqtt payload on corresponding channel
+          socket.emit(
+            `status-${component}-${subComponent}`,
+            global.statusPayloads[component][subComponent],
+          );
 
-    socket.on('send-video-feed-payloads', () => {
-      socket.emit(`camera-video-feed-status`, global.lastVideoFeedPayloads);
+          console.log(
+            `emit: status-${component}-${subComponent}: ${JSON.stringify(
+              global.statusPayloads[component][subComponent],
+            )}`,
+          );
+        });
+      });
     });
 
     socket.on('start-camera-recording', () => {


### PR DESCRIPTION
## Description

Before:

- Lots of copied code
- Many variables for status messages
- Inconsistent topic and channel names

Now:

- Consistent topic and channel names
- MQTT topics can be captured with the /v3/status root
- A single global object for storing status payloads
- Dynamically create socket.io listeners based on contents of global status object

Topics are changed in [raspicam#44](https://github.com/monash-human-power/raspicam/pull/44) and [common#7](https://github.com/monash-human-power/common/pull/7).

## Steps to Test

1. Start `mosquitto`

2. Start `raspicam` with `overlay_new` or any other overlay

3. Start dashboard `server` and `client`
