### PR TITLE
Add indicator for the connection between the camera and mqtt broker

### DIFF
--- a/client/.eslintrc
+++ b/client/.eslintrc
@@ -8,8 +8,12 @@
   ],
   "rules": {
     "no-console": "off",
-    "dot-notation": [2, { "allowPattern": "^[a-z]+(_[a-z]+)+$" }],
-    "react/jsx-filename-extension": [1, { "extensions": [".js"] }],
+    "dot-notation": [2, {
+      "allowPattern": "^[a-z]+(_[a-z]+)+$"
+    }],
+    "react/jsx-filename-extension": [1, {
+      "extensions": [".js"]
+    }],
     "react/jsx-props-no-spreading": "off",
     "jsx-a11y/label-has-associated-control": [
       2,
@@ -20,6 +24,7 @@
     ],
     "jsx-a11y/anchor-is-valid": "off",
     "import/no-unresolved": "off",
-    "import/prefer-default-export": "off"
+    "import/prefer-default-export": "off",
+    "semi": "error"
   }
 }

--- a/client/src/api/v2/camera.js
+++ b/client/src/api/v2/camera.js
@@ -193,3 +193,30 @@ export function useVideoFeedStatus() {
 
   return payload;
 }
+
+/**
+ * @typedef {object} CameraStatus
+ * @property {boolean}  online Whether camera is connected / not connected
+ */
+/**
+ * Returns the last received connection status of the camera client to the mqtt broker
+ *
+ * @param {string} device Device
+ * @returns {CameraStatus} Camera status
+ */
+export function useCameraStatus(device) {
+  // Only run init once per render
+  useEffect(() => {
+    emit(`status-camera-${device}`);
+  }, [device]);
+
+  const [state, setState] = useState(false);
+
+  const handler = useCallback((newPayload) => {
+    setState(newPayload.connected);
+  }, []);
+
+  useChannel(`status-camera-${device}`, handler);
+
+  return state;
+}

--- a/client/src/api/v2/sensors/status.js
+++ b/client/src/api/v2/sensors/status.js
@@ -1,6 +1,3 @@
-import { useCallback, useEffect, useState } from 'react';
-import { getPrettyDeviceName } from '../camera';
-import { emit, useChannel } from '../socket';
 import { useData } from './data';
 
 /**
@@ -52,28 +49,4 @@ export function useStatus() {
     potentiometer: !!data.pot,
     thermometer: !!data.thermoC,
   });
-}
-
-/**
- * Returns the last received connection status of the camera client to the mqtt broker
- *
- * @param {string} device Device
- * @returns {SensorStatus} Sensor status
- */
-export function useCameraStatus(device) {
-  // Only run init once per render
-  useEffect(() => {
-    emit(`status-camera-${device}`);
-  }, [device]);
-
-  const [state, setState] = useState(false);
-
-  const handler = useCallback((newPayload) => {
-    console.log(newPayload.connected);
-    setState(newPayload.connected);
-  }, []);
-
-  useChannel(`status-camera-${device}`, handler);
-
-  return { label: `${getPrettyDeviceName(device)} Camera`, name: `${device}`, state };
 }

--- a/client/src/api/v2/sensors/status.js
+++ b/client/src/api/v2/sensors/status.js
@@ -1,3 +1,6 @@
+import { useCallback, useEffect, useState } from 'react';
+import { getPrettyDeviceName } from '../camera';
+import { emit, useChannel } from '../socket';
 import { useData } from './data';
 
 /**
@@ -49,4 +52,28 @@ export function useStatus() {
     potentiometer: !!data.pot,
     thermometer: !!data.thermoC,
   });
+}
+
+/**
+ * Returns the last received connection status of the camera client to the mqtt broker
+ *
+ * @param {string} device Device
+ * @returns {SensorStatus} Sensor status
+ */
+export function useCameraStatus(device) {
+  // Only run init once per render
+  useEffect(() => {
+    emit(`status-camera-${device}`);
+  }, [device]);
+
+  const [state, setState] = useState(false);
+
+  const handler = useCallback((newPayload) => {
+    console.log(newPayload.connected);
+    setState(newPayload.connected);
+  }, []);
+
+  useChannel(`status-camera-${device}`, handler);
+
+  return { label: `${getPrettyDeviceName(device)} Camera`, name: `${device}`, state };
 }

--- a/client/src/components/v2/CameraRecording.js
+++ b/client/src/components/v2/CameraRecording.js
@@ -43,7 +43,7 @@ export default function CameraRecording({ devices }) {
                   {status[device]?.online ? 'ON' : 'OFF'}
                 </Badge>
                 <span className={styles.deviceName}>
-                  {`${getPrettyDeviceName(device)} Camera`}
+                  {`${getPrettyDeviceName(device)} Feed`}
                 </span>
               </Card.Subtitle>
               <CameraRecordingStatus device={device} />

--- a/client/src/components/v2/CameraStatus.js
+++ b/client/src/components/v2/CameraStatus.js
@@ -1,0 +1,38 @@
+import { getPrettyDeviceName, useCameraStatus } from 'api/v2/camera';
+import PropTypes from 'prop-types';
+import React from 'react';
+import { Badge } from 'react-bootstrap';
+
+/**
+ * @typedef {object} CameraStatusProps
+ * @property {string} devices Device names
+ */
+
+/**
+ * Camera recording buttons for starting and stopping video recording.
+ *
+ * Starts/stops recording for both displays.
+ *
+ * This is a feature intended for V3 but is currently in V2 for testing.
+ *
+ * @param {CameraStatusProps} props Props
+ * @returns {React.Component<CameraStatusProps>} Component
+ */
+export default function CameraStatus({ device }) {
+    const status = useCameraStatus(device);
+
+    return (
+        <>
+            <Badge pill variant={status ? 'success' : 'danger'}>
+                {status ? 'Connected' : 'Disconnected'}
+            </Badge><br/>
+            <span>
+                {`${getPrettyDeviceName(device)} Camera`}
+            </span>
+        </>
+    );
+}
+
+CameraStatus.propTypes = {
+    device: PropTypes.string.isRequired,
+};

--- a/client/src/views/v2/CameraSettingsView.js
+++ b/client/src/views/v2/CameraSettingsView.js
@@ -1,7 +1,9 @@
-import React from 'react';
 import ContentPage from 'components/ContentPage';
-import CameraSettings from 'components/v2/CameraSettings';
 import CameraRecording from 'components/v2/CameraRecording';
+import CameraSettings from 'components/v2/CameraSettings';
+import CameraStatus from 'components/v2/CameraStatus';
+import React from 'react';
+import { Card, Col, Row } from 'react-bootstrap';
 
 /**
  * Camera Settings page component
@@ -11,6 +13,19 @@ import CameraRecording from 'components/v2/CameraRecording';
 export default function CameraSettingsView() {
   return (
     <ContentPage title="Camera Settings">
+      <div className="mb-4">
+        <Card>
+          <Card.Body>
+            <Card.Title>Camera Status</Card.Title>
+            <Card.Subtitle>
+              <Row>
+                <Col><CameraStatus device="primary" /></Col>
+                <Col><CameraStatus device="secondary" /></Col>
+              </Row>
+            </Card.Subtitle>
+          </Card.Body>
+        </Card>
+      </div>
       <div className="mb-4">
         <CameraRecording devices={['primary', 'secondary']} />
       </div>

--- a/client/src/views/v2/SensorStatusView.js
+++ b/client/src/views/v2/SensorStatusView.js
@@ -1,4 +1,4 @@
-import { useCameraStatus, useStatus } from 'api/v2/sensors';
+import { useStatus } from 'api/v2/sensors';
 import ContentPage from 'components/ContentPage';
 import WidgetListGroupItem from 'components/WidgetListGroupItem';
 import React from 'react';
@@ -11,9 +11,6 @@ import { Badge, ListGroup } from 'react-bootstrap';
  */
 export default function SensorStatusView() {
   const sensorStatus = useStatus();
-
-  sensorStatus.push(useCameraStatus("primary"));
-  sensorStatus.push(useCameraStatus("secondary"));
 
   const sensorItems = sensorStatus.map(({ label, name, state }) => (
     <WidgetListGroupItem title={label} key={name}>

--- a/client/src/views/v2/SensorStatusView.js
+++ b/client/src/views/v2/SensorStatusView.js
@@ -1,8 +1,8 @@
-import React from 'react';
-import { Badge, ListGroup } from 'react-bootstrap';
+import { useCameraStatus, useStatus } from 'api/v2/sensors';
 import ContentPage from 'components/ContentPage';
 import WidgetListGroupItem from 'components/WidgetListGroupItem';
-import { useStatus } from 'api/v2/sensors';
+import React from 'react';
+import { Badge, ListGroup } from 'react-bootstrap';
 
 /**
  * Sensor Status page component
@@ -11,6 +11,9 @@ import { useStatus } from 'api/v2/sensors';
  */
 export default function SensorStatusView() {
   const sensorStatus = useStatus();
+
+  sensorStatus.push(useCameraStatus("primary"));
+  sensorStatus.push(useCameraStatus("secondary"));
 
   const sensorItems = sensorStatus.map(({ label, name, state }) => (
     <WidgetListGroupItem title={label} key={name}>

--- a/server/js/sockets.js
+++ b/server/js/sockets.js
@@ -22,6 +22,8 @@ global.statusPayloads = {
       primary: {},
       secondary: {},
     },
+    primary: {},
+    secondary: {},
   },
 };
 
@@ -180,9 +182,14 @@ sockets.init = function socketInit(server) {
         const subComponent = topicString[4];
         const device = topicString[5];
         // Store last received payload for device globally
-        global.statusPayloads[component][subComponent][device] = JSON.parse(
-          payloadString,
-        );
+        if (device)
+          global.statusPayloads[component][subComponent][device] = JSON.parse(
+            payloadString,
+          );
+        else
+          global.statusPayloads[component][subComponent] = JSON.parse(
+            payloadString,
+          );
 
         // Send mqtt payload on corresponding channel
         socket.emit(


### PR DESCRIPTION
## Description

Add an indicator on the `/v2/status` page for the primary and secondary camera to show when they are connected to the mqtt broker.

The code server-side is a bit hacky, but that will get refactored (again) later as I plan to fix up how client and server communicate so it's more streamlined (and dynamic). I have a card on Notion which describes this - "Dealing with retained and/or periodic mqtt messages between raspicam and dashboard"

Related to [raspicam#45](https://github.com/monash-human-power/raspicam/pull/45) and [common#9](https://github.com/monash-human-power/common/pull/9).

## Screenshots

![image](https://user-images.githubusercontent.com/50545432/92302800-3f185d80-efb2-11ea-9ed6-1d051babd6fc.png)

## Steps to Test

1. Start `mosquitto`

2. Start `raspicam` using `overlay_new.py` (or any other overlay)

3. Start `server` and `client` from dashboard