### PR TITLE
Specify nodejs version (14)

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   },
   "cacheDirectories": ["client/node_modules", "server/node_modules"],
   "engines": {
-    "yarn": "1.x"
+    "yarn": "1.x",
+    "node": "14.x"
   }
 }


### PR DESCRIPTION
## Description

[Heroku uses the latest LTS version](https://devcenter.heroku.com/articles/nodejs-support#specifying-a-node-js-version) of `nodejs` by default, currently version 12. We use the null coaleasing operator, which is [only supported by node versions >=14](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing_operator), causing our `master` branch deploys to fail to run, despite building. This PR specifies to Heroku what version of node we need.

## Screenshots

n/a

## Steps to Test

Check that this PR's deploy works.

Deploy here: https://mhp-board-hallgchris-he-fs6xun.herokuapp.com/