### PR TITLE
Update MQTT topics

### DIFF
--- a/client/src/api/v2/camera.js
+++ b/client/src/api/v2/camera.js
@@ -210,11 +210,11 @@ export const useCameraRecordingStatus = createStatusPayloadHook('recording', {
  * @property {boolean}  online Whether video feed is on/off
  */
 /**
- * Returns the last received status of the video feeds from `/v3/camera/video-feed/status/<primary/secondary>`
+ * Returns the last received status of the video feeds from `/v3/camera/video_feed/status/<primary/secondary>`
  *
  * @returns {object.<string, VideoFeedStatus>} A VideoFeedStatus for each device
  */
-export const useVideoFeedStatus = createStatusPayloadHook('video-feed', {
+export const useVideoFeedStatus = createStatusPayloadHook('video_feed', {
   initValue: {},
 });
 

--- a/server/js/sockets.js
+++ b/server/js/sockets.js
@@ -121,7 +121,7 @@ sockets.init = function socketInit(server) {
         Subscribe with the other topics and add a new message handler
         for the topics
     */
-    mqttClient.subscribe('/v3/status/#');
+    mqttClient.subscribe('status/#');
 
     mqttClient.on('message', function mqttMessage(topic, payload) {
       const payloadString = payload.toString();
@@ -170,11 +170,11 @@ sockets.init = function socketInit(server) {
             console.error(`Unhandled topic - ${topic}`);
             break;
         }
-      } else if (topic.match(/^\/v3\/status/)) {
+      } else if (topic.match(/^status/)) {
         try {
-          // topicString: ["", "v3", "status", "<component>", "<subcomponent>", ...properties]
+          // topicString: ["", "status", "<component>", "<subcomponent>", ...properties]
           const value = JSON.parse(payloadString);
-          const path = topicString.slice(2);
+          const path = topicString;
 
           // Add to global
           retained[path[0]] = setPropWithPath(
@@ -184,8 +184,8 @@ sockets.init = function socketInit(server) {
           );
 
           // Emit subcomponent
-          const component = topicString[3] ?? '';
-          const subcomponent = topicString[4] ?? '';
+          const component = topicString[1] ?? '';
+          const subcomponent = topicString[2] ?? '';
           socket.emit(
             `status-${component}-${subcomponent}`,
             retained.status?.[component]?.[subcomponent],

--- a/server/js/sockets.js
+++ b/server/js/sockets.js
@@ -100,6 +100,8 @@ sockets.init = function socketInit(server) {
   mqttClient.subscribe(BOOST.predicted_max_speed);
   mqttClient.subscribe(BOOST.recommended_sp);
   mqttClient.subscribe(Camera.push_overlays);
+  // TODO: This subscription should be removed when handling of BOOST.generate.complete
+  // is implemented.
   mqttClient.subscribe('power_model/plan_generated');
   // Camera recording status subscription occurs when mqttClient message handler is set
   // Camera video feed status subscription occurs when mqttClient message handler is set
@@ -181,6 +183,8 @@ sockets.init = function socketInit(server) {
               queryStringToJson(payloadString),
             );
             break;
+          // TODO: Remove this when handling of
+          // BOOST.generate.complete is implemented.
           case 'power_model/plan_generated':
             socket.emit('power-model-running');
             socket.emit('power-plan-generated');

--- a/server/js/topics.js
+++ b/server/js/topics.js
@@ -48,24 +48,24 @@ class Camera {
 class WirelessModule {
   static base = '/v3/wireless_module/';
 
-  battery(module_id = '+') {
-    return `${base}${module_id}/battery`;
+  static battery(module_id = '+') {
+    return `${WirelessModule.base}${module_id}/battery`;
   }
 
   static data(module_id = '+') {
     return `${WirelessModule.base}${module_id}/data`;
   }
 
-  start(module_id = '+') {
-    return `${base}${module_id}/start`;
+  static start(module_id = '+') {
+    return `${WirelessModule.base}${module_id}/start`;
   }
 
-  stop(module_id = '+') {
-    return `${base}${module_id}/stop`;
+  static stop(module_id = '+') {
+    return `${WirelessModule.base}${module_id}/stop`;
   }
 
-  module(module_id = '+') {
-    return `${base}${module_id}/#`;
+  static module(module_id = '+') {
+    return `${WirelessModule.base}${module_id}/#`;
   }
 }
 

--- a/server/js/topics.js
+++ b/server/js/topics.js
@@ -46,26 +46,22 @@ class Camera {
 }
 
 class WirelessModule {
-  static base = '/v3/wireless_module/';
+  static base = '/v3/wireless_module';
 
-  static battery(module_id = '+') {
-    return `${WirelessModule.base}${module_id}/battery`;
+  static id(module_id = '+') {
+    const module_base = `${WirelessModule.base}/${module_id}`;
+    return {
+      base: module_base,
+      battery: `${module_base}/battery`,
+      data: `${module_base}/data`,
+      start: `${module_base}/start`,
+      stop: `${module_base}/stop`,
+      module: `${module_base}/module`,
+    };
   }
 
-  static data(module_id = '+') {
-    return `${WirelessModule.base}${module_id}/data`;
-  }
-
-  static start(module_id = '+') {
-    return `${WirelessModule.base}${module_id}/start`;
-  }
-
-  static stop(module_id = '+') {
-    return `${WirelessModule.base}${module_id}/stop`;
-  }
-
-  static module(module_id = '+') {
-    return `${WirelessModule.base}${module_id}/#`;
+  static all() {
+    return WirelessModule.id('+');
   }
 }
 

--- a/server/js/topics.js
+++ b/server/js/topics.js
@@ -1,0 +1,77 @@
+class DAS {
+  static data = 'data';
+  static start = 'start';
+  static stop = 'stop';
+}
+
+class BOOST {
+  // Start/stop
+  static start = 'boost/start';
+  static stop = 'boost/stop';
+
+  // BOOST output
+  static recommended_sp = 'boost/recommended_sp';
+  static predicted_max_speed = 'boost/predicted_max_speed';
+
+  // Plan generation
+  static generate = 'boost/generate';
+  static generate_complete = 'boost/generate_complete';
+
+  // Distance calibration
+  static calibrate = 'boost/calibrate';
+  static calibrate_reset = 'boost/calibrate/reset';
+}
+
+class Camera {
+  // Getting/setting overlays
+  static get_overlays = 'camera/get_overlays';
+  static set_overlay = 'camera/set_overlay';
+  static push_overlays = 'camera/push_overlays';
+
+  // Error topic
+  static errors = 'camera/errors';
+
+  // Messages to be shown on DAShboard
+  static overlay_message = 'camera/message';
+
+  // Recording
+  static recording = 'camera/recording/+';
+  static recording_start = 'camera/recording/start';
+  static recording_stop = 'camera/recording/stop';
+
+  // Camera status
+  static status_recording = 'status/camera/recording';
+  static status_video_feed = 'status/camera/video_feed';
+  static status_camera = 'status/camera';
+}
+
+class WirelessModule {
+  static base = '/v3/wireless_module/';
+
+  battery(module_id = '+') {
+    return `${base}${module_id}/battery`;
+  }
+
+  static data(module_id = '+') {
+    return `${WirelessModule.base}${module_id}/data`;
+  }
+
+  start(module_id = '+') {
+    return `${base}${module_id}/start`;
+  }
+
+  stop(module_id = '+') {
+    return `${base}${module_id}/stop`;
+  }
+
+  module(module_id = '+') {
+    return `${base}${module_id}/#`;
+  }
+}
+
+module.exports = {
+  DAS,
+  BOOST,
+  Camera,
+  WirelessModule,
+};


### PR DESCRIPTION
## Description

This PR adds `topics.js`, which imitates [`topics.py` from the common repo](https://github.com/monash-human-power/common/blob/hallgchris/mqtt-refactor/mhp/topics/topics.py). Hopefully this will make it easier to keep topics in sync in the future! It would be good to have something similar for socket.io topics eventually.

There are still lots of places that don't use `topics.js` due to not checking the whole topic at once, but breaking it down into sections. This is a bit harder to work with - and for stuff like how we currently handle status topics is just a trade-off we have to deal with.

## Screenshots

n/a

## Steps to Test

Confirm that all the website features work as expected. Keep in mind that if you're testing them with other projects, you'll need to use the updated PRs for them too so that they MQTT topics match!