### PR TITLE
Add MIT license to all package.json files

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,7 @@
 {
   "name": "client",
   "version": "0.1.0",
+  "license": "MIT",
   "private": true,
   "dependencies": {
     "@fortawesome/fontawesome-common-types": "^0.2.26",

--- a/package.json
+++ b/package.json
@@ -1,9 +1,13 @@
 {
+  "license": "MIT",
   "scripts": {
     "heroku-prebuild": "cd client && yarn install && CI=true yarn build && cd .. && cd server && yarn install",
     "start": "cd server && yarn start"
   },
-  "cacheDirectories": ["client/node_modules", "server/node_modules"],
+  "cacheDirectories": [
+    "client/node_modules",
+    "server/node_modules"
+  ],
   "engines": {
     "yarn": "1.x",
     "node": "14.x"

--- a/server/package.json
+++ b/server/package.json
@@ -16,7 +16,7 @@
   },
   "keywords": [],
   "author": "",
-  "license": "ISC",
+  "license": "MIT",
   "bugs": {
     "url": "https://github.com/khanguslee/MHP-DAS-Web-Server/issues"
   },


### PR DESCRIPTION
## Description
Every single time that `yarn install` is run a license warning is triggered. This PR stops the annoying warning by putting a license in every package.json file.


## Screenshots

<img width="404" alt="image" src="https://user-images.githubusercontent.com/23159604/106069231-39d0d080-6156-11eb-9ff7-b32c9f924323.png">

Fixes the no license warning 

## Steps to Test

Look at the 3 lines changed.
