### PR TITLE
Add API functions for accessing wireless module data

### DIFF
--- a/client/src/api/common/data.ts
+++ b/client/src/api/common/data.ts
@@ -63,7 +63,9 @@ export function useSensorData<T extends SensorsT>(
     const module = useModuleData(id);
 
     // Data from sensor
-    const data = module.sensors.find((s) => s.type === sensor)?.value ?? null;
+    const data = module.sensors
+        .find((s) => s.type === sensor)  // Data for the sensor
+        ?.value ?? null;  // Extract value, defaulting to null
 
     return Union(shape, Null).check(data);
 }

--- a/client/src/api/common/data.ts
+++ b/client/src/api/common/data.ts
@@ -1,0 +1,36 @@
+import { useState } from "react";
+import { Array, Record, Static, String, Unknown } from "runtypes";
+import { useChannelShaped } from "./socket";
+
+export interface ModuleDataProps {
+    /** Module id */
+    id: number,
+}
+
+const ModuleDataT = Record({
+    /** Sensor data */
+    sensors: Array(Record({
+        /** Type of data */
+        type: String,
+        /** Value */
+        value: Unknown
+    }))
+});
+
+type _ModuleDataT = Static<typeof ModuleDataT>;
+
+export interface ModuleDataT extends _ModuleDataT {}
+
+/**
+ * Pass on incoming data from the wireless module channel
+ *
+ * @param id ID of module
+ * @returns Data
+ */
+export function useModuleData({id}: ModuleDataProps): ModuleDataT {
+    const [data, setData] = useState<ModuleDataT>({ sensors: [] });
+
+    useChannelShaped(`module-${id}-data`, ModuleDataT, setData);
+
+    return data;
+}

--- a/client/src/api/common/data.ts
+++ b/client/src/api/common/data.ts
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { Array, Record, Static, String, Unknown } from "runtypes";
 import { useChannelShaped } from "./socket";
 
-const ModuleDataT = Record({
+const ModuleData = Record({
     /** Sensor data */
     sensors: Array(Record({
         /** Type of data */
@@ -12,9 +12,9 @@ const ModuleDataT = Record({
     }))
 });
 
-type _ModuleDataT = Static<typeof ModuleDataT>;
+type _ModuleData = Static<typeof ModuleData>;
 
-export interface ModuleDataT extends _ModuleDataT {}
+export interface ModuleData extends _ModuleData {}
 
 /**
  * Pass on incoming data from the wireless module channel
@@ -22,10 +22,10 @@ export interface ModuleDataT extends _ModuleDataT {}
  * @param id ID of module
  * @returns Data
  */
-export function useModuleData(id: number): ModuleDataT {
-    const [data, setData] = useState<ModuleDataT>({ sensors: [] });
+export function useModuleData(id: number): ModuleData {
+    const [data, setData] = useState<ModuleData>({ sensors: [] });
 
-    useChannelShaped(`module-${id}-data`, ModuleDataT, setData);
+    useChannelShaped(`module-${id}-data`, ModuleData, setData);
 
     return data;
 }

--- a/client/src/api/common/data.ts
+++ b/client/src/api/common/data.ts
@@ -1,6 +1,25 @@
 import { useState } from "react";
-import { Array, Record, Static, String, Unknown } from "runtypes";
+import { Array, Null, Record, Runtype, Static, String, Union, Unknown } from "runtypes";
+import { SensorsT } from "types/data";
 import { useChannelShaped } from "./socket";
+
+/** Enumerates the sensors available.
+ *  Value should correspond to the sensor "type" attribute.
+ */
+export enum Sensor {
+    Temperature = 'temperature',
+    Humidity = 'humidity',
+    SteeringAngle = 'steeringAngle',
+    CO2 = 'co2',
+    Accelerometer = 'accelerometer',
+    Gyroscope = 'gyroscope',
+    ReedVelocity = 'reedVelocity',
+    ReedDistance = 'reedDistance',
+    GPS = 'gps',
+    Power = 'power',
+    Cadence = 'cadence',
+    HeartRate = 'heartRate'
+}
 
 const ModuleData = Record({
     /** Sensor data */
@@ -28,4 +47,23 @@ export function useModuleData(id: number): ModuleData {
     useChannelShaped(`module-${id}-data`, ModuleData, setData);
 
     return data;
+}
+
+/**
+ * Extract sensor data from incoming module data
+ *
+ * @param id ID of module
+ * @param sensor Sensor type
+ * @param shape Shape of data value
+ * @returns Value of sensor data
+ */
+export function useSensorData<T extends SensorsT>(
+    id: number, sensor: Sensor, shape: Runtype<T>
+): T | null {
+    const module = useModuleData(id);
+
+    // Data from sensor
+    const data = module.sensors.find((s) => s.type === sensor)?.value ?? null;
+
+    return Union(shape, Null).check(data);
 }

--- a/client/src/api/common/data.ts
+++ b/client/src/api/common/data.ts
@@ -2,11 +2,6 @@ import { useState } from "react";
 import { Array, Record, Static, String, Unknown } from "runtypes";
 import { useChannelShaped } from "./socket";
 
-export interface ModuleDataProps {
-    /** Module id */
-    id: number,
-}
-
 const ModuleDataT = Record({
     /** Sensor data */
     sensors: Array(Record({
@@ -27,7 +22,7 @@ export interface ModuleDataT extends _ModuleDataT {}
  * @param id ID of module
  * @returns Data
  */
-export function useModuleData({id}: ModuleDataProps): ModuleDataT {
+export function useModuleData(id: number): ModuleDataT {
     const [data, setData] = useState<ModuleDataT>({ sensors: [] });
 
     useChannelShaped(`module-${id}-data`, ModuleDataT, setData);

--- a/client/src/types/data.ts
+++ b/client/src/types/data.ts
@@ -106,4 +106,7 @@ export type CadenceT = Static<typeof CadenceRT>
 export type HeartRateT = Static<typeof HeartRateRT>
 
 /** Union type of all sensor value types */
-export type SensorsT = TemperatureT | HumidityT | SteeringAngleT | CO2T | AccelerometerT | GyroscopeT | ReedVelocityT | ReedDistanceT | GPST | PowerT | CadenceT | HeartRateT;
+export type SensorsT = TemperatureT | HumidityT | SteeringAngleT
+    | CO2T | AccelerometerT | GyroscopeT
+    | ReedVelocityT | ReedDistanceT | GPST
+    | PowerT | CadenceT | HeartRateT;

--- a/client/src/types/data.ts
+++ b/client/src/types/data.ts
@@ -1,0 +1,109 @@
+import { Number, Record, Static } from "runtypes";
+
+/* ------------------------------------ RunTypes ------------------------------------ */
+
+/** Value runtype of temperature sensor data */
+export const TemperatureRT = Number;
+
+/** Value runtype of humidity sensor data */
+export const HumidityRT = Number;
+
+/** Value runtype of steeringAngle sensor data */
+export const SteeringAngleRT = Number;
+
+/** Value runtype of co2 sensor data */
+export const CO2RT = Number;
+
+/** Value runtype of accelerometer sensor data */
+export const AccelerometerRT = Record({
+    /** X value */
+    x: Number,
+    /** Y value */
+    y: Number,
+    /** Z value */
+    z: Number
+});
+
+/** Value runtype of gyroscope sensor data */
+export const GyroscopeRT = Record({
+    /** X value */
+    x: Number,
+    /** Y value */
+    y: Number,
+    /** Z value */
+    z: Number
+});
+
+/** Value runtype of reedVelocity sensor data */
+export const ReedVelocityRT = Number;
+
+/** Value runtype of reedDistance sensor data */
+export const ReedDistanceRT = Number;
+
+/** Value runtype of gps sensor data */
+export const GPSRT = Record({
+    /** Speed */
+    speed: Number,
+    // /** Dilution of precision */
+    // pdop: Number,
+    /** Latitude */
+    latitude: Number,
+    /** Longitude */
+    longitude: Number,
+    /** Altitude */
+    altitude: Number,
+    /** Course */
+    course: Number,
+    // /** Datetime */
+    // datetime: String
+});
+
+/** Value runtype of power sensor data */
+export const PowerRT = Number;
+
+/** Value runtype of cadence sensor data */
+export const CadenceRT = Number;
+
+/** Value runtype of heartRate sensor data */
+export const HeartRateRT = Number;
+
+/* ------------------------------------ Types ------------------------------------ */
+
+/** Value type of temperature sensor data */
+export type TemperatureT = Static<typeof TemperatureRT>
+
+/** Value type of humidity sensor data */
+export type HumidityT = Static<typeof HumidityRT>
+
+/** Value type of steeringAngle sensor data */
+export type SteeringAngleT = Static<typeof SteeringAngleRT>
+
+/** Value type of co2 sensor data */
+export type CO2T = Static<typeof CO2RT>
+
+/** Value type of accelerometer sensor data */
+export type AccelerometerT = Static<typeof AccelerometerRT>
+
+/** Value type of gyroscope sensor data */
+export type GyroscopeT = Static<typeof GyroscopeRT>
+
+/** Value type of reedVelocity sensor data */
+export type ReedVelocityT = Static<typeof ReedVelocityRT>
+
+/** Value type of reedDistance sensor data */
+export type ReedDistanceT = Static<typeof ReedDistanceRT>
+
+/** Value type of gps sensor data */
+export type GPST = Static<typeof GPSRT>
+
+/** Value type of power sensor data */
+export type PowerT = Static<typeof PowerRT>
+
+/** Value type of cadence sensor data */
+export type CadenceT = Static<typeof CadenceRT>
+
+/** Value type of heartRate sensor data */
+export type HeartRateT = Static<typeof HeartRateRT>
+
+/** Union type of all sensor value types */
+export type SensorsT = TemperatureT | HumidityT | SteeringAngleT | CO2T | AccelerometerT | GyroscopeT | ReedVelocityT | ReedDistanceT | GPST | PowerT | CadenceT | HeartRateT;

--- a/client/src/types/data.ts
+++ b/client/src/types/data.ts
@@ -1,4 +1,4 @@
-import { Number, Record, Static } from "runtypes";
+import { Number, Record, Static, String } from "runtypes";
 
 /* ------------------------------------ RunTypes ------------------------------------ */
 
@@ -44,8 +44,8 @@ export const ReedDistanceRT = Number;
 export const GPSRT = Record({
     /** Speed */
     speed: Number,
-    // /** Dilution of precision */
-    // pdop: Number,
+    /** Dilution of precision */
+    pdop: Number,
     /** Latitude */
     latitude: Number,
     /** Longitude */
@@ -54,8 +54,8 @@ export const GPSRT = Record({
     altitude: Number,
     /** Course */
     course: Number,
-    // /** Datetime */
-    // datetime: String
+    /** Datetime */
+    datetime: String
 });
 
 /** Value runtype of power sensor data */

--- a/server/js/sockets.js
+++ b/server/js/sockets.js
@@ -97,6 +97,7 @@ sockets.init = function socketInit(server) {
   mqttClient.subscribe(DAS.start);
   mqttClient.subscribe(DAS.stop);
   mqttClient.subscribe(DAS.data);
+  mqttClient.subscribe(`${WirelessModule.base}/#`);
   mqttClient.subscribe(BOOST.predicted_max_speed);
   mqttClient.subscribe(BOOST.recommended_sp);
   mqttClient.subscribe(Camera.push_overlays);
@@ -154,7 +155,7 @@ sockets.init = function socketInit(server) {
             `Error in parsing received payload\n\ttopic: ${topic}\n\tpayload: ${payloadString}\n`,
           );
         }
-      } else if (topic.startswith(WirelessModule.base)) {
+      } else if (topic.startsWith(WirelessModule.base)) {
         // Emit on appropriate channel
         try {
           const topicString = topic.split('/').slice(1); // Remove leading ""

--- a/server/js/sockets.js
+++ b/server/js/sockets.js
@@ -158,11 +158,9 @@ sockets.init = function socketInit(server) {
       } else if (topic.startsWith(WirelessModule.base)) {
         // Emit on appropriate channel
         try {
-          const topicString = topic.split('/').slice(1); // Remove leading ""
+          const [, , id, property] = topic.split('/').slice(1); // Remove leading ""
           // topicString: ["v3", "wireless_module", <id>, <property>]
           const value = JSON.parse(payloadString);
-          const id = topicString[2];
-          const property = topicString[3];
 
           // Emit parsed payload as is
           socket.emit(`module-${id}-${property}`, value);

--- a/server/js/sockets.js
+++ b/server/js/sockets.js
@@ -160,9 +160,11 @@ sockets.init = function socketInit(server) {
           const topicString = topic.split('/').slice(1); // Remove leading ""
           // topicString: ["v3", "wireless_module", <id>, <property>]
           const value = JSON.parse(payloadString);
+          const id = topicString[2];
+          const property = topicString[3];
 
           // Emit parsed payload as is
-          socket.emit(`module-${topicString[2]}-${topicString[3]}`, value);
+          socket.emit(`module-${id}-${property}`, value);
 
           // If needs to be retained, that can be implemented here
         } catch (e) {

--- a/server/js/sockets.js
+++ b/server/js/sockets.js
@@ -117,6 +117,8 @@ sockets.init = function socketInit(server) {
   // eslint-disable-next-line global-require
   const io = require('socket.io').listen(server);
   io.on('connection', function ioConnection(socket) {
+    socket.setMaxListeners(20);
+
     /*
       Must subscribe to these when the mqtt message handler is set
       otherwise the retained payloads will not be handled.

--- a/server/js/sockets.js
+++ b/server/js/sockets.js
@@ -97,7 +97,7 @@ sockets.init = function socketInit(server) {
   mqttClient.subscribe(DAS.start);
   mqttClient.subscribe(DAS.stop);
   mqttClient.subscribe(DAS.data);
-  mqttClient.subscribe(`${WirelessModule.base}/#`);
+  mqttClient.subscribe(WirelessModule.all().module);
   mqttClient.subscribe(BOOST.predicted_max_speed);
   mqttClient.subscribe(BOOST.recommended_sp);
   mqttClient.subscribe(Camera.push_overlays);

--- a/server/js/topics.js
+++ b/server/js/topics.js
@@ -56,7 +56,7 @@ class WirelessModule {
       data: `${module_base}/data`,
       start: `${module_base}/start`,
       stop: `${module_base}/stop`,
-      module: `${module_base}/module`,
+      module: `${module_base}/#`,
     };
   }
 


### PR DESCRIPTION
## Description

Server
- Subscribe to wireless module channels
- Translates MQTT messages to socket.io emits

Client
- Hook for module data

## Steps to Test

1. Start mosquitto
2. Navigate to DAS and run `V3_fake_module`
3. Start server
4. Start client

~~There are currently no components using the API right now. For testing, I used the `useModuleData` hook in `DashboardView` just to log the data to console.~~

Use the following code in `src/views/v3/DashboardView.tsx`

```typescript
import { Sensor, useSensorData } from 'api/common/data';
import ContentPage from 'components/common/ContentPage';
import React from 'react';
import { GPSRT } from 'types/data';


/**
 * Dashboard View component
 *
 * @returns {React.Component} Component
 */
export default function DashboardView() {
    const gpsSpeed = useSensorData(3, Sensor.GPS, GPSRT)?.speed;
    return <ContentPage>GPS speed: {gpsSpeed || 'n/a'} m/s</ContentPage>;
};
```