### PR TITLE
Add logic to `BoostConfigurator`'s upload button

### DIFF
--- a/client/src/api/v3/boost.ts
+++ b/client/src/api/v3/boost.ts
@@ -2,7 +2,7 @@ import { emit } from 'api/common/socket';
 import { BoostConfigType } from 'types/boost';
 
 /**
- * Sends the content of the given configuration file on `boost/configs/action` over MQTT
+ * Send the content of the given configuration file on `boost/configs/action` over MQTT
  *
  * @param type the type of the configuration being sent
  * @param configFiles list of files, only the first would be considered

--- a/client/src/api/v3/boost.ts
+++ b/client/src/api/v3/boost.ts
@@ -2,7 +2,7 @@ import { emit } from 'api/common/socket';
 import { BoostConfigType } from 'types/boost';
 
 /**
- * Sends the content of the given configuration file on 'boost/configs/action' over MQTT
+ * Sends the content of the given configuration file on `boost/configs/action` over MQTT
  *
  * @param type the type of the configuration being sent
  * @param configFiles list of files, only the first would be considered

--- a/client/src/api/v3/boost.ts
+++ b/client/src/api/v3/boost.ts
@@ -1,0 +1,22 @@
+// import { emit } from 'api/common/socket';
+import { BoostConfigType } from 'types/boost';
+
+export default function uploadConfig(configType: BoostConfigType, configFiles: FileList) {
+    const reader = new FileReader();
+    reader.onload = () => {
+        console.log(reader.result);
+    };
+
+    reader.readAsText(configFiles[0]);
+
+    // const topic = "boost/configs/action";
+    // const payload = {
+    //     "action": "upload",
+    //     "configType": configType,
+    //     "content": {
+    //         // json file contents here
+    //     },
+    // };
+
+    // emit('submit-calibration', payload);
+}

--- a/client/src/api/v3/boost.ts
+++ b/client/src/api/v3/boost.ts
@@ -17,6 +17,7 @@ export default function uploadConfig(configType: BoostConfigType, configFiles: F
         const payload = {
             "action": "upload",
             "configType": configType,
+            "configName": configFiles[0].name,
             "content": reader.result,
         };
         emit(topic, JSON.stringify(payload).replace(/\\n/g, ''));

--- a/client/src/api/v3/boost.ts
+++ b/client/src/api/v3/boost.ts
@@ -11,7 +11,7 @@ export default function uploadConfig(
   type: BoostConfigType,
   configFile: File,
 ) {
-  const topic = 'send-uploaded-config';
+  const topic = 'send-config';
   const reader = new FileReader();
 
   // Called when FileReader has completed reading a file

--- a/client/src/api/v3/boost.ts
+++ b/client/src/api/v3/boost.ts
@@ -3,25 +3,28 @@ import { BoostConfigType } from 'types/boost';
 
 /**
  * Sends the content of the given configuration file on 'boost/configs/action' over MQTT
- * 
+ *
  * @param configType the type of the configuration being sent
  * @param configFiles list of files, only the first would be considered
  */
-export default function uploadConfig(configType: BoostConfigType, configFiles: FileList) {
-    const topic = 'send-config';
-    const reader = new FileReader();
-    
-    // Called when FileReader has completed reading a file
-    reader.onload = () => {
-        console.log(reader.result);
-        const payload = {
-            "action": "upload",
-            "configType": configType,
-            "configName": configFiles[0].name,
-            "content": reader.result,
-        };
-        emit(topic, JSON.stringify(payload).replace(/\\n/g, ''));
-    };
+export default function uploadConfig(
+  configType: BoostConfigType,
+  configFiles: FileList,
+) {
+  const topic = 'send-config';
+  const reader = new FileReader();
 
-    reader.readAsText(configFiles[0]);
+  // Called when FileReader has completed reading a file
+  reader.onload = () => {
+    console.log(reader.result);
+    const payload = {
+      action: 'upload',
+      configType: configType,
+      configName: configFiles[0].name,
+      content: reader.result,
+    };
+    emit(topic, JSON.stringify(payload).replace(/\\n/g, ''));
+  };
+
+  reader.readAsText(configFiles[0]);
 }

--- a/client/src/api/v3/boost.ts
+++ b/client/src/api/v3/boost.ts
@@ -20,7 +20,6 @@ export default function uploadConfig(
     const payload = {
       action: 'upload',
       configType: type,
-      configName: configFile.name,
       content: reader.result,
     };
     emit(topic, JSON.stringify(payload));

--- a/client/src/api/v3/boost.ts
+++ b/client/src/api/v3/boost.ts
@@ -11,7 +11,7 @@ export default function uploadConfig(
   type: BoostConfigType,
   configFiles: FileList,
 ) {
-  const topic = 'send-config';
+  const topic = 'send-uploaded-config';
   const reader = new FileReader();
 
   // Called when FileReader has completed reading a file

--- a/client/src/api/v3/boost.ts
+++ b/client/src/api/v3/boost.ts
@@ -4,11 +4,11 @@ import { BoostConfigType } from 'types/boost';
 /**
  * Sends the content of the given configuration file on 'boost/configs/action' over MQTT
  *
- * @param configType the type of the configuration being sent
+ * @param type the type of the configuration being sent
  * @param configFiles list of files, only the first would be considered
  */
 export default function uploadConfig(
-  configType: BoostConfigType,
+  type: BoostConfigType,
   configFiles: FileList,
 ) {
   const topic = 'send-config';
@@ -19,7 +19,7 @@ export default function uploadConfig(
     console.log(reader.result);
     const payload = {
       action: 'upload',
-      configType: configType,
+      configType: type,
       configName: configFiles[0].name,
       content: reader.result,
     };

--- a/client/src/api/v3/boost.ts
+++ b/client/src/api/v3/boost.ts
@@ -1,10 +1,17 @@
 import { emit } from 'api/common/socket';
 import { BoostConfigType } from 'types/boost';
 
+/**
+ * Sends the content of the given configuration file on 'boost/configs/action' over MQTT
+ * 
+ * @param configType the type of the configuration being sent
+ * @param configFiles list of files, only the first would be considered
+ */
 export default function uploadConfig(configType: BoostConfigType, configFiles: FileList) {
     const topic = 'boost/configs/action';
     const reader = new FileReader();
     
+    // Called when FileReader has completed reading a file
     reader.onload = () => {
         console.log(reader.result);
         const payload = {
@@ -12,7 +19,7 @@ export default function uploadConfig(configType: BoostConfigType, configFiles: F
             "configType": configType,
             "content": reader.result,
         };
-        emit(topic, JSON.stringify(payload));
+        emit(topic, JSON.stringify(payload).replace(/\\n/g, ''));
     };
 
     reader.readAsText(configFiles[0]);

--- a/client/src/api/v3/boost.ts
+++ b/client/src/api/v3/boost.ts
@@ -5,11 +5,11 @@ import { BoostConfigType } from 'types/boost';
  * Send the content of the given configuration file on `boost/configs/action` over MQTT
  *
  * @param type the type of the configuration being sent
- * @param configFiles list of files, only the first would be considered
+ * @param configFile list of files, only the first would be considered
  */
 export default function uploadConfig(
   type: BoostConfigType,
-  configFiles: FileList,
+  configFile: File,
 ) {
   const topic = 'send-uploaded-config';
   const reader = new FileReader();
@@ -20,11 +20,11 @@ export default function uploadConfig(
     const payload = {
       action: 'upload',
       configType: type,
-      configName: configFiles[0].name,
+      configName: configFile.name,
       content: reader.result,
     };
     emit(topic, JSON.stringify(payload).replace(/\\n/g, ''));
   };
 
-  reader.readAsText(configFiles[0]);
+  reader.readAsText(configFile);
 }

--- a/client/src/api/v3/boost.ts
+++ b/client/src/api/v3/boost.ts
@@ -23,7 +23,7 @@ export default function uploadConfig(
       configName: configFile.name,
       content: reader.result,
     };
-    emit(topic, JSON.stringify(payload).replace(/\\n/g, ''));
+    emit(topic, JSON.stringify(payload));
   };
 
   reader.readAsText(configFile);

--- a/client/src/api/v3/boost.ts
+++ b/client/src/api/v3/boost.ts
@@ -8,7 +8,7 @@ import { BoostConfigType } from 'types/boost';
  * @param configFiles list of files, only the first would be considered
  */
 export default function uploadConfig(configType: BoostConfigType, configFiles: FileList) {
-    const topic = 'boost/configs/action';
+    const topic = 'send-config';
     const reader = new FileReader();
     
     // Called when FileReader has completed reading a file

--- a/client/src/api/v3/boost.ts
+++ b/client/src/api/v3/boost.ts
@@ -5,7 +5,7 @@ import { BoostConfigType } from 'types/boost';
  * Send the content of the given configuration file on `boost/configs/action` over MQTT
  *
  * @param type the type of the configuration being sent
- * @param configFile list of files, only the first would be considered
+ * @param configFile file containing the configuration content
  */
 export default function uploadConfig(
   type: BoostConfigType,

--- a/client/src/api/v3/boost.ts
+++ b/client/src/api/v3/boost.ts
@@ -1,22 +1,19 @@
-// import { emit } from 'api/common/socket';
+import { emit } from 'api/common/socket';
 import { BoostConfigType } from 'types/boost';
 
 export default function uploadConfig(configType: BoostConfigType, configFiles: FileList) {
+    const topic = 'boost/configs/action';
     const reader = new FileReader();
+    
     reader.onload = () => {
         console.log(reader.result);
+        const payload = {
+            "action": "upload",
+            "configType": configType,
+            "content": reader.result,
+        };
+        emit(topic, JSON.stringify(payload));
     };
 
     reader.readAsText(configFiles[0]);
-
-    // const topic = "boost/configs/action";
-    // const payload = {
-    //     "action": "upload",
-    //     "configType": configType,
-    //     "content": {
-    //         // json file contents here
-    //     },
-    // };
-
-    // emit('submit-calibration', payload);
 }

--- a/client/src/components/common/boost/BoostConfigurator.tsx
+++ b/client/src/components/common/boost/BoostConfigurator.tsx
@@ -48,7 +48,16 @@ export default function BoostConfigurator({
   return (
     <Card style={{ marginTop: '2.5rem' }}>
       <Card.Body>
-        <Card.Title>Configuration</Card.Title>
+        <Card.Title style={{ marginBottom: '1.5rem' }}>
+          Configuration
+        <Button
+            variant="outline-primary"
+            className="float-right"
+            onClick={() => handleClickUpload('all')}
+          >
+            Upload All Configs
+          </Button>
+        </Card.Title>
         <>
           <input
             ref={fileInput}
@@ -58,13 +67,6 @@ export default function BoostConfigurator({
             accept=".json"
             multiple={false}
           />
-          <Button
-            variant="outline-primary"
-            className="mb-3"
-            onClick={() => handleClickUpload('all')}
-          >
-            Upload All Configs
-          </Button>
         </>
         <Accordion>
           {configs.map((config, index) => (
@@ -80,6 +82,7 @@ export default function BoostConfigurator({
                 <Button
                   variant="outline-primary"
                   className="float-right mb-1"
+                  size="sm"
                   onClick={(e) => {
                     e.stopPropagation();
                     handleClickUpload(config.type);

--- a/client/src/components/common/boost/BoostConfigurator.tsx
+++ b/client/src/components/common/boost/BoostConfigurator.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useRef, useState} from 'react';
 import { Accordion, Button, Card } from 'react-bootstrap';
 import { BoostConfig, BoostConfigType } from 'types/boost';
 import { camelCaseToStartCase } from 'utils/string';
@@ -8,7 +8,7 @@ export interface BoostConfiguratorProps {
   configs: BoostConfig[];
   onSelectConfig: (configType: BoostConfigType, name: string) => void;
   onDeleteConfig: (configType: BoostConfigType, name: string) => void;
-  onUploadConfig: () => void;
+  onUploadConfig: (configType: BoostConfigType, configFiles: FileList) => void;
 }
 
 /** 
@@ -23,17 +23,36 @@ export default function BoostConfigurator({
   onDeleteConfig,
   onUploadConfig,
 }: BoostConfiguratorProps) {
+  const fileInput = useRef(null);
+  const [configType, setConfigType] = useState<BoostConfigType>('powerPlan');
+
+  const handleClick = (type: string) => {
+    if (fileInput.current != null) {
+      setConfigType("rider");
+      fileInput.current.click();
+    };
+  };
+
+  const handleFileUpload = (event: React.ChangeEvent<HTMLInputElement>) => {
+    if (event.target.files != null) {
+      onUploadConfig(configType, event.target.files);
+    }
+  };
+
   return (
     <Card>
       <Card.Body>
         <Card.Title>Configuration</Card.Title>
-        <Button
-          variant="outline-primary"
-          className="mb-3"
-          onClick={onUploadConfig}
-        >
-          Upload config
-        </Button>
+        <>
+          <input
+            ref={fileInput}
+            onChange={(e) => {handleFileUpload}}
+            type="file"
+            style={{ display: "none" }}
+            multiple={false}
+          />
+          <Button variant="outline-primary" className="mb-3" onClick={() => {handleClick("all")}}>Upload Config</Button>
+      </>
         <Accordion>
           {configs.map((config, index) => (
             <Card>

--- a/client/src/components/common/boost/BoostConfigurator.tsx
+++ b/client/src/components/common/boost/BoostConfigurator.tsx
@@ -38,7 +38,8 @@ export default function BoostConfigurator({
   };
 
   const handleFileUpload = (event: React.ChangeEvent<HTMLInputElement>) => {
-    // This method gets called even if the user uploads a file and the second time they cancel to upload, hence the need to check that the files attribute is not an array of 0 length
+    // This method gets called even if the user uploads a file and the second time they cancel
+    // to upload, hence the need to check that the files attribute is not an array of 0 length
     if (event.target.files != null && event.target.files.length !== 0) {
       onUploadConfig(configType, event.target.files);
     }

--- a/client/src/components/common/boost/BoostConfigurator.tsx
+++ b/client/src/components/common/boost/BoostConfigurator.tsx
@@ -52,6 +52,7 @@ export default function BoostConfigurator({
             onChange={handleFileUpload}
             type="file"
             style={{ display: "none" }}
+            accept=".json"
             multiple={false}
           />
           <Button variant="outline-primary" className="mb-3" onClick={() => {handleClick('all');}}>

--- a/client/src/components/common/boost/BoostConfigurator.tsx
+++ b/client/src/components/common/boost/BoostConfigurator.tsx
@@ -61,9 +61,7 @@ export default function BoostConfigurator({
           <Button
             variant="outline-primary"
             className="mb-3"
-            onClick={() => {
-              handleClickUpload('all');
-            }}
+            onClick={() => handleClickUpload('all')}
           >
             Upload All Configs
           </Button>

--- a/client/src/components/common/boost/BoostConfigurator.tsx
+++ b/client/src/components/common/boost/BoostConfigurator.tsx
@@ -1,4 +1,6 @@
 import React, {useRef, useState} from 'react';
+// import { faFileUpload } from '@fortawesome/free-solid-svg-icons';
+// import FontAwesomeIcon from 'components/common/FontAwesomeIcon';
 import { Accordion, Button, Card } from 'react-bootstrap';
 import { BoostConfig, BoostConfigType } from 'types/boost';
 import { camelCaseToStartCase } from 'utils/string';
@@ -24,11 +26,11 @@ export default function BoostConfigurator({
   onUploadConfig,
 }: BoostConfiguratorProps) {
   const fileInput = useRef(null);
-  const [configType, setConfigType] = useState<BoostConfigType>('powerPlan');
+  const [configType, setConfigType] = useState<BoostConfigType>('all');
 
-  const handleClick = (type: string) => {
+  const handleClick = (type: BoostConfigType) => {
     if (fileInput.current != null) {
-      setConfigType("rider");
+      setConfigType(type);
       fileInput.current.click();
     };
   };
@@ -46,12 +48,14 @@ export default function BoostConfigurator({
         <>
           <input
             ref={fileInput}
-            onChange={(e) => {handleFileUpload}}
+            onChange={handleFileUpload}
             type="file"
             style={{ display: "none" }}
             multiple={false}
           />
-          <Button variant="outline-primary" className="mb-3" onClick={() => {handleClick("all")}}>Upload Config</Button>
+          <Button variant="outline-primary" className="mb-3" onClick={() => {handleClick('all');}}>
+            Upload All Configs
+          </Button>
       </>
         <Accordion>
           {configs.map((config, index) => (

--- a/client/src/components/common/boost/BoostConfigurator.tsx
+++ b/client/src/components/common/boost/BoostConfigurator.tsx
@@ -37,9 +37,9 @@ export default function BoostConfigurator({
     }
   };
 
+  // This method gets called even if the user uploads a file and the second time they cancel
+  // to upload, hence the need to check that the files attribute is not an array of 0 length
   const handleFileUpload = (event: React.ChangeEvent<HTMLInputElement>) => {
-    // This method gets called even if the user uploads a file and the second time they cancel
-    // to upload, hence the need to check that the files attribute is not an array of 0 length
     if (event.target.files != null && event.target.files.length !== 0) {
       onUploadConfig(configType, event.target.files);
     }

--- a/client/src/components/common/boost/BoostConfigurator.tsx
+++ b/client/src/components/common/boost/BoostConfigurator.tsx
@@ -1,6 +1,6 @@
 import React, {useRef, useState} from 'react';
-// import { faFileUpload } from '@fortawesome/free-solid-svg-icons';
-// import FontAwesomeIcon from 'components/common/FontAwesomeIcon';
+import { faFileUpload } from '@fortawesome/free-solid-svg-icons';
+import FontAwesomeIcon from 'components/common/FontAwesomeIcon';
 import { Accordion, Button, Card } from 'react-bootstrap';
 import { BoostConfig, BoostConfigType } from 'types/boost';
 import { camelCaseToStartCase } from 'utils/string';
@@ -68,6 +68,7 @@ export default function BoostConfigurator({
                 {camelCaseToStartCase(config.type)}
                 {': '}
                 <i>{config.active ? `"${config.active}"` : 'None'}</i>
+                <Button variant="outline-primary" className="float-right mb-1" onClick={(e) => {e.stopPropagation(); handleClick(config.type);}}><FontAwesomeIcon icon={faFileUpload} /></Button>
               </Accordion.Toggle>
               <Accordion.Collapse eventKey={String(index)}>
                 <Card.Body>

--- a/client/src/components/common/boost/BoostConfigurator.tsx
+++ b/client/src/components/common/boost/BoostConfigurator.tsx
@@ -30,7 +30,7 @@ export default function BoostConfigurator({
 
   // Function to click the hidden file input button (this is a work around to avoid the ugly
   // UI of the default input file button)
-  const handleClick = (type: BoostConfigType) => {
+  const handleClickUpload = (type: BoostConfigType) => {
     if (fileInput.current) {
       setConfigType(type);
       fileInput.current.click();
@@ -62,7 +62,7 @@ export default function BoostConfigurator({
             variant="outline-primary"
             className="mb-3"
             onClick={() => {
-              handleClick('all');
+              handleClickUpload('all');
             }}
           >
             Upload All Configs
@@ -84,7 +84,7 @@ export default function BoostConfigurator({
                   className="float-right mb-1"
                   onClick={(e) => {
                     e.stopPropagation();
-                    handleClick(config.type);
+                    handleClickUpload(config.type);
                   }}
                 >
                   <FontAwesomeIcon icon={faFileUpload} />

--- a/client/src/components/common/boost/BoostConfigurator.tsx
+++ b/client/src/components/common/boost/BoostConfigurator.tsx
@@ -45,7 +45,7 @@ export default function BoostConfigurator({
   };
 
   return (
-    <Card>
+    <Card style={{ marginTop: '2.5rem' }}>
       <Card.Body>
         <Card.Title>Configuration</Card.Title>
         <>

--- a/client/src/components/common/boost/BoostConfigurator.tsx
+++ b/client/src/components/common/boost/BoostConfigurator.tsx
@@ -1,4 +1,4 @@
-import React, {useRef, useState} from 'react';
+import React, {createRef, useState} from 'react';
 import { faFileUpload } from '@fortawesome/free-solid-svg-icons';
 import FontAwesomeIcon from 'components/common/FontAwesomeIcon';
 import { Accordion, Button, Card } from 'react-bootstrap';
@@ -25,11 +25,12 @@ export default function BoostConfigurator({
   onDeleteConfig,
   onUploadConfig,
 }: BoostConfiguratorProps) {
-  const fileInput = useRef(null);
+  // const fileInput = useRef(null);
+  const fileInput = createRef<HTMLInputElement>();
   const [configType, setConfigType] = useState<BoostConfigType>('all');
 
   const handleClick = (type: BoostConfigType) => {
-    if (fileInput.current != null) {
+    if (fileInput.current) {
       setConfigType(type);
       fileInput.current.click();
     };

--- a/client/src/components/common/boost/BoostConfigurator.tsx
+++ b/client/src/components/common/boost/BoostConfigurator.tsx
@@ -25,10 +25,11 @@ export default function BoostConfigurator({
   onDeleteConfig,
   onUploadConfig,
 }: BoostConfiguratorProps) {
-  // const fileInput = useRef(null);
   const fileInput = createRef<HTMLInputElement>();
   const [configType, setConfigType] = useState<BoostConfigType>('all');
 
+  // Function to click the hidden file input button (this is a work around to avoid the ugly
+  // UI of the default input file button)
   const handleClick = (type: BoostConfigType) => {
     if (fileInput.current) {
       setConfigType(type);
@@ -37,7 +38,8 @@ export default function BoostConfigurator({
   };
 
   const handleFileUpload = (event: React.ChangeEvent<HTMLInputElement>) => {
-    if (event.target.files != null) {
+    // This method gets called even if the user uploads a file and the second time they cancel to upload, hence the need to check that the files attribute is not an array of 0 length
+    if (event.target.files != null && event.target.files.length !== 0) {
       onUploadConfig(configType, event.target.files);
     }
   };

--- a/client/src/components/common/boost/BoostConfigurator.tsx
+++ b/client/src/components/common/boost/BoostConfigurator.tsx
@@ -1,4 +1,4 @@
-import React, {createRef, useState} from 'react';
+import React, { createRef, useState } from 'react';
 import { faFileUpload } from '@fortawesome/free-solid-svg-icons';
 import FontAwesomeIcon from 'components/common/FontAwesomeIcon';
 import { Accordion, Button, Card } from 'react-bootstrap';
@@ -13,7 +13,7 @@ export interface BoostConfiguratorProps {
   onUploadConfig: (configType: BoostConfigType, configFiles: FileList) => void;
 }
 
-/** 
+/**
  * TODO: Add real docs for this component
  *
  * @param props Props
@@ -34,7 +34,7 @@ export default function BoostConfigurator({
     if (fileInput.current) {
       setConfigType(type);
       fileInput.current.click();
-    };
+    }
   };
 
   const handleFileUpload = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -53,14 +53,20 @@ export default function BoostConfigurator({
             ref={fileInput}
             onChange={handleFileUpload}
             type="file"
-            style={{ display: "none" }}
+            style={{ display: 'none' }}
             accept=".json"
             multiple={false}
           />
-          <Button variant="outline-primary" className="mb-3" onClick={() => {handleClick('all');}}>
+          <Button
+            variant="outline-primary"
+            className="mb-3"
+            onClick={() => {
+              handleClick('all');
+            }}
+          >
             Upload All Configs
           </Button>
-      </>
+        </>
         <Accordion>
           {configs.map((config, index) => (
             <Card>
@@ -72,7 +78,16 @@ export default function BoostConfigurator({
                 {camelCaseToStartCase(config.type)}
                 {': '}
                 <i>{config.active ? `"${config.active}"` : 'None'}</i>
-                <Button variant="outline-primary" className="float-right mb-1" onClick={(e) => {e.stopPropagation(); handleClick(config.type);}}><FontAwesomeIcon icon={faFileUpload} /></Button>
+                <Button
+                  variant="outline-primary"
+                  className="float-right mb-1"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    handleClick(config.type);
+                  }}
+                >
+                  <FontAwesomeIcon icon={faFileUpload} />
+                </Button>
               </Accordion.Toggle>
               <Accordion.Collapse eventKey={String(index)}>
                 <Card.Body>

--- a/client/src/components/common/boost/BoostConfigurator.tsx
+++ b/client/src/components/common/boost/BoostConfigurator.tsx
@@ -10,7 +10,7 @@ export interface BoostConfiguratorProps {
   configs: BoostConfig[];
   onSelectConfig: (configType: BoostConfigType, name: string) => void;
   onDeleteConfig: (configType: BoostConfigType, name: string) => void;
-  onUploadConfig: (configType: BoostConfigType, configFiles: FileList) => void;
+  onUploadConfig: (configType: BoostConfigType, configFile: File) => void;
 }
 
 /**
@@ -41,7 +41,7 @@ export default function BoostConfigurator({
   // to upload, hence the need to check that the files attribute is not an array of 0 length
   const handleFileUpload = (event: React.ChangeEvent<HTMLInputElement>) => {
     if (event.target.files != null && event.target.files.length !== 0) {
-      onUploadConfig(configType, event.target.files);
+      onUploadConfig(configType, event.target.files[0]);
     }
   };
 

--- a/client/src/types/boost.ts
+++ b/client/src/types/boost.ts
@@ -1,4 +1,4 @@
-export type BoostConfigType = 'powerPlan' | 'rider' | 'bike' | 'track';
+export type BoostConfigType = 'powerPlan' | 'rider' | 'bike' | 'track' | 'all';
 
 export interface BoostConfig {
   /** The input of BOOST that this config is for */

--- a/client/src/views/common/BoostView.tsx
+++ b/client/src/views/common/BoostView.tsx
@@ -6,6 +6,7 @@ import {setCalibration, resetCalibration} from 'api/common/powerModel';
 import uploadConfig from 'api/v3/boost';
 import { BoostConfigType, BoostConfig } from 'types/boost';
 
+//TODO: Implement actual functions for `onSelectConfig`, `onDeleteConfig` and true values for `baseConfigs` (provided from boost)
 function onSelectConfig(configType: BoostConfigType, name: string) {
     console.log("onSelect clicked for:");
     console.log(configType);
@@ -18,6 +19,7 @@ function onDeleteConfig(configType: BoostConfigType, name: string) {
     console.log(name);
 }
 
+// Only test data
 const baseConfigs: BoostConfig[] = [
     {
       type: 'powerPlan',
@@ -51,6 +53,7 @@ export default function BoostView() {
     return (
         <ContentPage title="Boost Configuration">
             <BoostCalibration onSet={setCalibration} onReset={resetCalibration} distTravelled={30} calibrationDiff={10}/>
+            <p></p>
             <BoostConfigurator configs={baseConfigs} onSelectConfig={onSelectConfig} onDeleteConfig={onDeleteConfig} onUploadConfig={uploadConfig} />
         </ContentPage>
     );

--- a/client/src/views/common/BoostView.tsx
+++ b/client/src/views/common/BoostView.tsx
@@ -6,24 +6,30 @@ import { setCalibration, resetCalibration } from 'api/common/powerModel';
 import uploadConfig from 'api/v3/boost';
 import { BoostConfigType, BoostConfig } from 'types/boost';
 
-// TODO: Implement actual functions for `onSelectConfig`, `onDeleteConfig` and true values for `baseConfigs` (provided from boost)
+// TODO: Implement actual functions for `onSelectConfig`, `onDeleteConfig` and true values for `baseConfigs` (provided from `boost`)
 
 /**
- * Send the config selection to boost
+ * Send the config selection to `boost`
+ * 
  * @param configType the type of the config
  * @param name name of the config file
  */
 function onSelectConfig(configType: BoostConfigType, name: string) {
-  return;
+  console.log("Selected config:");
+  console.log(`type: ${configType}`);
+  console.log(`name: ${name}`);
 }
 
 /**
  * Inform boost of the deletion of the given config file
+ * 
  * @param configType the type of the config
  * @param name name of the config file
  */
 function onDeleteConfig(configType: BoostConfigType, name: string) {
-  return;
+  console.log("Deleted config:");
+  console.log(`type: ${configType}`);
+  console.log(`name: ${name}`);
 }
 
 // Only dummy data

--- a/client/src/views/common/BoostView.tsx
+++ b/client/src/views/common/BoostView.tsx
@@ -53,7 +53,6 @@ export default function BoostView() {
     return (
         <ContentPage title="Boost Configuration">
             <BoostCalibration onSet={setCalibration} onReset={resetCalibration} distTravelled={30} calibrationDiff={10}/>
-            <p></p>
             <BoostConfigurator configs={baseConfigs} onSelectConfig={onSelectConfig} onDeleteConfig={onDeleteConfig} onUploadConfig={uploadConfig} />
         </ContentPage>
     );

--- a/client/src/views/common/BoostView.tsx
+++ b/client/src/views/common/BoostView.tsx
@@ -6,13 +6,24 @@ import {setCalibration, resetCalibration} from 'api/common/powerModel';
 import uploadConfig from 'api/v3/boost';
 import { BoostConfigType, BoostConfig } from 'types/boost';
 
-//TODO: Implement actual functions for `onSelectConfig`, `onDeleteConfig` and true values for `baseConfigs` (provided from boost)
+// TODO: Implement actual functions for `onSelectConfig`, `onDeleteConfig` and true values for `baseConfigs` (provided from boost)
+
+/**
+ * Send the config selection to boost
+ * @param configType the type of the config
+ * @param name name of the config file
+ */
 function onSelectConfig(configType: BoostConfigType, name: string) {
     console.log("onSelect clicked for:");
     console.log(configType);
     console.log(name);
 } 
 
+/**
+ * Inform boost of the deletion of the given config file
+ * @param configType the type of the config
+ * @param name name of the config file
+ */
 function onDeleteConfig(configType: BoostConfigType, name: string) {
     console.log("onDelete clicked for:");
     console.log(configType);

--- a/client/src/views/common/BoostView.tsx
+++ b/client/src/views/common/BoostView.tsx
@@ -1,7 +1,45 @@
 import React from 'react';
 import ContentPage from 'components/common/ContentPage';
 import BoostCalibration from 'components/common/boost/BoostCalibration';
+import BoostConfigurator from 'components/common/boost/BoostConfigurator';
 import {setCalibration, resetCalibration} from 'api/common/powerModel';
+import uploadConfig from 'api/v3/boost';
+import { BoostConfigType, BoostConfig } from 'types/boost';
+
+function onSelectConfig(configType: BoostConfigType, name: string) {
+    console.log("onSelect clicked for:");
+    console.log(configType);
+    console.log(name);
+} 
+
+function onDeleteConfig(configType: BoostConfigType, name: string) {
+    console.log("onDelete clicked for:");
+    console.log(configType);
+    console.log(name);
+}
+
+const baseConfigs: BoostConfig[] = [
+    {
+      type: 'powerPlan',
+      options: ['my_plan_1.json', 'this_one_gets_you_to_144.json'],
+      active: 'my_plan_1.json',
+    },
+    {
+      type: 'rider',
+      options: ['al.json', 'charles.json'],
+      active: 'charles.json',
+    },
+    {
+      type: 'bike',
+      options: ['blacksmith.json', 'wombat.json', 'precilla.json'],
+      active: 'wombat.json',
+    },
+    {
+      type: 'track',
+      options: ['ford.json', 'holden.json', 'battle_mountain.json'],
+      active: 'ford.json',
+    },
+  ];
 
 /**
  * Boost View component
@@ -13,6 +51,7 @@ export default function BoostView() {
     return (
         <ContentPage title="Boost Configuration">
             <BoostCalibration onSet={setCalibration} onReset={resetCalibration} distTravelled={30} calibrationDiff={10}/>
+            <BoostConfigurator configs={baseConfigs} onSelectConfig={onSelectConfig} onDeleteConfig={onDeleteConfig} onUploadConfig={uploadConfig} />
         </ContentPage>
     );
 };

--- a/client/src/views/common/BoostView.tsx
+++ b/client/src/views/common/BoostView.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import ContentPage from 'components/common/ContentPage';
 import BoostCalibration from 'components/common/boost/BoostCalibration';
 import BoostConfigurator from 'components/common/boost/BoostConfigurator';
-import {setCalibration, resetCalibration} from 'api/common/powerModel';
+import { setCalibration, resetCalibration } from 'api/common/powerModel';
 import uploadConfig from 'api/v3/boost';
 import { BoostConfigType, BoostConfig } from 'types/boost';
 
@@ -14,8 +14,8 @@ import { BoostConfigType, BoostConfig } from 'types/boost';
  * @param name name of the config file
  */
 function onSelectConfig(configType: BoostConfigType, name: string) {
-    return;
-} 
+  return;
+}
 
 /**
  * Inform boost of the deletion of the given config file
@@ -23,32 +23,32 @@ function onSelectConfig(configType: BoostConfigType, name: string) {
  * @param name name of the config file
  */
 function onDeleteConfig(configType: BoostConfigType, name: string) {
-    return;
+  return;
 }
 
 // Only dummy data
 const baseConfigs: BoostConfig[] = [
-    {
-      type: 'powerPlan',
-      options: ['my_plan_1.json', 'this_one_gets_you_to_144.json'],
-      active: 'my_plan_1.json',
-    },
-    {
-      type: 'rider',
-      options: ['al.json', 'charles.json'],
-      active: 'charles.json',
-    },
-    {
-      type: 'bike',
-      options: ['blacksmith.json', 'wombat.json', 'precilla.json'],
-      active: 'wombat.json',
-    },
-    {
-      type: 'track',
-      options: ['ford.json', 'holden.json', 'battle_mountain.json'],
-      active: 'ford.json',
-    },
-  ];
+  {
+    type: 'powerPlan',
+    options: ['my_plan_1.json', 'this_one_gets_you_to_144.json'],
+    active: 'my_plan_1.json',
+  },
+  {
+    type: 'rider',
+    options: ['al.json', 'charles.json'],
+    active: 'charles.json',
+  },
+  {
+    type: 'bike',
+    options: ['blacksmith.json', 'wombat.json', 'precilla.json'],
+    active: 'wombat.json',
+  },
+  {
+    type: 'track',
+    options: ['ford.json', 'holden.json', 'battle_mountain.json'],
+    active: 'ford.json',
+  },
+];
 
 /**
  * Boost View component
@@ -56,12 +56,21 @@ const baseConfigs: BoostConfig[] = [
  * @returns {React.Component} Component
  */
 export default function BoostView() {
-    // TODO: remove the hardcoded value for `distTravelled` with actual value read from MQTT
-    return (
-        <ContentPage title="Boost Configuration">
-            <BoostCalibration onSet={setCalibration} onReset={resetCalibration} distTravelled={30} calibrationDiff={10}/>
-            <BoostConfigurator configs={baseConfigs} onSelectConfig={onSelectConfig} onDeleteConfig={onDeleteConfig} onUploadConfig={uploadConfig} />
-        </ContentPage>
-    );
-};
-
+  // TODO: remove the hardcoded value for `distTravelled` with actual value read from MQTT
+  return (
+    <ContentPage title="Boost Configuration">
+      <BoostCalibration
+        onSet={setCalibration}
+        onReset={resetCalibration}
+        distTravelled={30}
+        calibrationDiff={10}
+      />
+      <BoostConfigurator
+        configs={baseConfigs}
+        onSelectConfig={onSelectConfig}
+        onDeleteConfig={onDeleteConfig}
+        onUploadConfig={uploadConfig}
+      />
+    </ContentPage>
+  );
+}

--- a/client/src/views/common/BoostView.tsx
+++ b/client/src/views/common/BoostView.tsx
@@ -14,9 +14,7 @@ import { BoostConfigType, BoostConfig } from 'types/boost';
  * @param name name of the config file
  */
 function onSelectConfig(configType: BoostConfigType, name: string) {
-    console.log("onSelect clicked for:");
-    console.log(configType);
-    console.log(name);
+    return;
 } 
 
 /**
@@ -25,12 +23,10 @@ function onSelectConfig(configType: BoostConfigType, name: string) {
  * @param name name of the config file
  */
 function onDeleteConfig(configType: BoostConfigType, name: string) {
-    console.log("onDelete clicked for:");
-    console.log(configType);
-    console.log(name);
+    return;
 }
 
-// Only test data
+// Only dummy data
 const baseConfigs: BoostConfig[] = [
     {
       type: 'powerPlan',

--- a/server/js/sockets.js
+++ b/server/js/sockets.js
@@ -222,7 +222,7 @@ sockets.init = function socketInit(server) {
       mqttClient.publish(BOOST.calibrate_reset, 'true');
     });
 
-    socket.on('send-uploaded-config', (configContent) => {
+    socket.on('send-config', (configContent) => {
       mqttClient.publish('boost/configs/action', configContent);
     });
 

--- a/server/js/sockets.js
+++ b/server/js/sockets.js
@@ -222,6 +222,10 @@ sockets.init = function socketInit(server) {
       mqttClient.publish(BOOST.calibrate_reset, 'true');
     });
 
+    socket.on('send-config', (configContent) => {
+      mqttClient.publish('boost/configs/action', configContent);
+    });
+
     socket.on('submit-calibration', (calibratedDistance) => {
       mqttClient.publish(BOOST.calibrate, `calibrate=${calibratedDistance}`);
     });

--- a/server/js/sockets.js
+++ b/server/js/sockets.js
@@ -222,7 +222,7 @@ sockets.init = function socketInit(server) {
       mqttClient.publish(BOOST.calibrate_reset, 'true');
     });
 
-    socket.on('send-config', (configContent) => {
+    socket.on('send-uploaded-config', (configContent) => {
       mqttClient.publish('boost/configs/action', configContent);
     });
 


### PR DESCRIPTION
## Description

Currently, the `BoostConfigurator` UI has no logic, this PR starts to change this with adding logic to the upload button as part of a series of related PRs. The UI has been slightly changed compared to the [initial sigma design](https://www.figma.com/file/HoZBPfj3QqhmbiDUyxn8Ag/Initial-Design?node-id=0%3A1 ) -> _Hint:_ notice the extra upload buttons next to each config type. 

The PR allows users to upload the 4 configs separately or all at once (combined in a single file) using the button named 'Upload all configs'. Users are restricted from uploading any files other than a `.json` and from uploading multiple files at once. The uploaded config is then sent to `BOOST` over mqtt (topic: `boost/configs/action`).

There are still things to complete (which will be targeted in future PRs since they rely on other changes to this or the `BOOST` repo) including:

- Restricting users from uploading the same config file again (at the moment, users are restricted from uploading the same file only if they do it consecutively)
- Double checking that the user has uploaded the right config file for the chosen config type
- Splitting the 'bundled' config files uploaded using the 'Upload all configs' button before sending them to boost. (If I understand correctly this will be done by `dashboard`, @hallgchris can you confirm?)
- Displaying the uploaded config in the drop down list (should we make `dashboard` automatically select it as well after upload?)

I have also updated the payload for the `boost/configs/action` topic to include the config file name as well. Refer to the new payload structure [here](https://www.notion.so/V3-MQTT-Topics-66e6715d0e1941ffaa82020e5868fbae#94fd423460aa401cb7edda3d5dec6b8d).
## Screenshots

<img width="1272" alt="Screen Shot 2021-02-23 at 11 49 00 am" src="https://user-images.githubusercontent.com/63642262/108790285-6995bb80-75d0-11eb-850f-dd046ac2d0d6.png">

<img width="1269" alt="Screen Shot 2021-02-23 at 11 49 48 am" src="https://user-images.githubusercontent.com/63642262/108790576-2ab43580-75d1-11eb-9db7-1a2edec25508.png">


## Steps to Test

1) in `client/` run storybook (`yarn run storybook`) to check everything is working in terms of the UI presentation
2) in `client/` run `yarn start` and try uploading a file on the boost page (notice you can't select more than one file or a `non-JSON` file). The file's content upon successfully uploading should appear in console (I have kept this since it allows for easy debugging without going through the effort of running the server and the mqtt subscription.
3) in 'server/' on another terminal run `yarn start` and in a 3rd terminal subscribe to the mqtt topic (`mosquitto_sub -h localhost -t 'boost/configs/action'`) and then

- try uploading different config files and check that they are sent on the mqtt topic.
