### PR TITLE
Fixes compilation error due to incorrect types in `BoostCalibration.tsx`

### DIFF
--- a/client/src/components/common/boost/BoostCalibration.tsx
+++ b/client/src/components/common/boost/BoostCalibration.tsx
@@ -33,7 +33,7 @@ export default function BoostCalibration({
   );
 
   const handleSubmit = useCallback(
-    (event: React.FormEvent<HTMLInputElement>) => {
+    (event: React.FormEvent<HTMLFormElement>) => {
       const form = event.currentTarget;
       if (form.checkValidity() === false) {
         event.stopPropagation();
@@ -44,13 +44,6 @@ export default function BoostCalibration({
       setValidated(true);
     },
     [calibValue, onSet, setValidated],
-  );
-
-  const handleKeyPressed = useCallback(
-    (event: React.KeyboardEvent<HTMLInputElement>) => {
-      if (event.key === 'Enter') handleSubmit(event);
-    },
-    [handleSubmit],
   );
 
   return (
@@ -84,7 +77,6 @@ export default function BoostCalibration({
               <Form.Control
                 type="number"
                 placeholder="Calibrate distance..."
-                onKeyPress={handleKeyPressed}
                 onChange={handleCalibrationChange}
                 required
               />


### PR DESCRIPTION
## Description

Uses `HTMLFormElement` rather than `HTMLInputElement` for `Form` event.
Removed redundant keypress handler for submitting form on enter.

Not sure why I didn't pick this up in the code review, but after I merged master I realised I was compiling with errors.

## Steps to Test

1. Execute `yarn start` or `yarn storybook` in `client`
