### PR TITLE
Add functionality to select and delete configs 

### DIFF
--- a/client/src/api/common/socket.ts
+++ b/client/src/api/common/socket.ts
@@ -44,7 +44,11 @@ export function useChannelShaped<T>(
 ) {
   const parsedCallback = (payload: string | object) => {
     const json = typeof payload === 'string' ? JSON.parse(payload) : payload;
-    callback(shape.check(json));
+    try {
+      callback(shape.check(json));
+    } catch {
+      console.log(`Channel ${channel} sending garbage`);
+    }
   };
   useChannel(channel, parsedCallback);
 }

--- a/client/src/api/v3/boost.ts
+++ b/client/src/api/v3/boost.ts
@@ -1,5 +1,12 @@
 import { emit } from 'api/common/socket';
-import { FileConfigT, ConfigObjRT, ConfigT } from 'types/boost';
+import {
+  FileConfigT,
+  ConfigObjRT,
+  ConfigT,
+  SelectedConfigsT,
+  BoostConfig,
+  ConfigNameT,
+} from 'types/boost';
 import { addSuffix } from 'utils/boost';
 import toast from 'react-hot-toast';
 import { Runtype, Static } from 'runtypes';
@@ -87,9 +94,37 @@ export default function uploadConfig(
  * @param configType the type of the config
  * @param name name of the config file
  */
-function onDeleteConfig(configType: ConfigT, name: string) {
+export function deleteConfig(configType: ConfigT, name: string) {
   // FIXME: Should dashboard remove the config file from `configs`?
   console.log(`Delete ${name} ${configType} config`);
   sendConfig('delete', configType, name, null);
   toast.success(`${name} deleted`);
+}
+
+/**
+ * Send the selected configs to `boost`
+ *
+ * @param configs contains all actively selected configs
+ */
+export function sendConfigSelections(
+  configs: BoostConfig[],
+  configTypeSelected: ConfigT,
+  configNameSelected: ConfigNameT,
+) {
+  const payload: SelectedConfigsT = {
+    rider: '',
+    bike: '',
+    track: '',
+    powerPlan: '',
+  };
+
+  // Populate payload with the currently active config for each config type
+  configs.forEach((config) => {
+    if (config.type === configTypeSelected) {
+      payload[configTypeSelected] = configNameSelected.displayName;
+    } else {
+      payload[config.type] = config.active?.displayName;
+    }
+  });
+  emit('submit-selected-configs', JSON.stringify(payload));
 }

--- a/client/src/api/v3/boost.ts
+++ b/client/src/api/v3/boost.ts
@@ -105,14 +105,8 @@ export function deleteConfig(configType: ConfigT, configName: ConfigNameT) {
  * Send the selected configs to `boost`
  *
  * @param configs contains all actively selected configs
- * @param configTypeSelected the config type of the new config file selected
- * @param configNameSelected object containing displayName and fileName of the new config selected
  */
-export function sendConfigSelections(
-  configs: BoostConfig[],
-  configTypeSelected: ConfigT,
-  configNameSelected: ConfigNameT,
-) {
+export function sendConfigSelections(configs: BoostConfig[]) {
   const payload: SelectedConfigsT = {
     rider: '',
     bike: '',
@@ -122,11 +116,8 @@ export function sendConfigSelections(
 
   // Populate payload with the currently active config for each config type
   configs.forEach((config) => {
-    if (config.type === configTypeSelected) {
-      payload[configTypeSelected] = configNameSelected.displayName;
-    } else {
-      payload[config.type] = config.active?.displayName;
-    }
+    payload[config.type] = config.active?.displayName;
   });
+  // Send selected configs to generate Power Plan
   emit('submit-selected-configs', JSON.stringify(payload));
 }

--- a/client/src/api/v3/boost.ts
+++ b/client/src/api/v3/boost.ts
@@ -80,3 +80,16 @@ export default function uploadConfig(
 
   reader.readAsText(configFile);
 }
+
+/**
+ * Inform boost of the deletion of the given config file
+ *
+ * @param configType the type of the config
+ * @param name name of the config file
+ */
+function onDeleteConfig(configType: ConfigT, name: string) {
+  // FIXME: Should dashboard remove the config file from `configs`?
+  console.log(`Delete ${name} ${configType} config`);
+  sendConfig('delete', configType, name, null);
+  toast.success(`${name} deleted`);
+}

--- a/client/src/api/v3/boost.ts
+++ b/client/src/api/v3/boost.ts
@@ -92,19 +92,21 @@ export default function uploadConfig(
  * Inform boost of the deletion of the given config file
  *
  * @param configType the type of the config
- * @param name name of the config file
+ * @param configName object containing displayName and fileName of the config
  */
-export function deleteConfig(configType: ConfigT, name: string) {
+export function deleteConfig(configType: ConfigT, configName: ConfigNameT) {
   // FIXME: Should dashboard remove the config file from `configs`?
-  console.log(`Delete ${name} ${configType} config`);
-  sendConfig('delete', configType, name, null);
-  toast.success(`${name} deleted`);
+  console.log(`Delete ${configName.displayName} ${configType} config`);
+  sendConfig('delete', configType, configName.displayName, null);
+  toast.success(`${configName.displayName} deleted`);
 }
 
 /**
  * Send the selected configs to `boost`
  *
  * @param configs contains all actively selected configs
+ * @param configTypeSelected the config type of the new config file selected
+ * @param configNameSelected object containing displayName and fileName of the new config selected
  */
 export function sendConfigSelections(
   configs: BoostConfig[],

--- a/client/src/api/v3/boost.ts
+++ b/client/src/api/v3/boost.ts
@@ -5,7 +5,6 @@ import {
   ConfigT,
   SelectedConfigsT,
   BoostConfig,
-  ConfigNameT,
 } from 'types/boost';
 import { addSuffix } from 'utils/boost';
 import toast from 'react-hot-toast';
@@ -21,7 +20,7 @@ type payloadActionT = 'upload' | 'delete';
  * @param name name of the config file
  * @param configContent configuration content
  */
-function sendConfig(
+export function sendConfig(
   actionType: payloadActionT,
   type: ConfigT,
   name: string,
@@ -86,19 +85,6 @@ export default function uploadConfig(
   };
 
   reader.readAsText(configFile);
-}
-
-/**
- * Inform boost of the deletion of the given config file
- *
- * @param configType the type of the config
- * @param configName object containing displayName and fileName of the config
- */
-export function deleteConfig(configType: ConfigT, configName: ConfigNameT) {
-  // FIXME: Should dashboard remove the config file from `configs`?
-  console.log(`Delete ${configName.displayName} ${configType} config`);
-  sendConfig('delete', configType, configName.displayName, null);
-  toast.success(`${configName.displayName} deleted`);
 }
 
 /**

--- a/client/src/components/common/boost/BoostConfigList.tsx
+++ b/client/src/components/common/boost/BoostConfigList.tsx
@@ -1,7 +1,7 @@
 import { faFile, faTrashAlt } from '@fortawesome/free-solid-svg-icons';
 import React from 'react';
 import { Button } from 'react-bootstrap';
-import { BoostConfig } from 'types/boost';
+import { BoostConfig, ConfigNameT } from 'types/boost';
 import FontAwesomeIcon from 'components/common/FontAwesomeIcon';
 import WidgetListGroupItem from 'components/common/WidgetListGroupItem';
 import styles from 'components/common/boost/BoostConfigList.module.css';
@@ -9,7 +9,7 @@ import { removeSuffix } from 'utils/boost';
 
 export interface BoostConfigListProps {
   config: BoostConfig;
-  onSelectConfig: (configName: string) => void;
+  onSelectConfig: (configName: ConfigNameT) => void;
   onDeleteConfig: (configName: string) => void;
 }
 
@@ -24,9 +24,8 @@ export default function BoostConfigList({
   onSelectConfig,
   onDeleteConfig,
 }: BoostConfigListProps) {
-  const handleSelect = (configFileName: string) => {
-    if (configFileName !== config.active?.fileName)
-      onSelectConfig(configFileName);
+  const handleSelect = (configName: ConfigNameT) => {
+    if (configName !== config.active) onSelectConfig(configName);
   };
   const handleDelete = (event: React.MouseEvent, configName: string) => {
     event.stopPropagation();
@@ -50,7 +49,7 @@ export default function BoostConfigList({
           title=""
           active={configName.fileName === config.active?.fileName}
           action
-          onClick={() => handleSelect(configName.fileName)}
+          onClick={() => handleSelect(configName)}
           as="a"
         >
           <span>

--- a/client/src/components/common/boost/BoostConfigList.tsx
+++ b/client/src/components/common/boost/BoostConfigList.tsx
@@ -28,7 +28,6 @@ export default function BoostConfigList({
     if (configName !== config.active) onSelectConfig(configName);
   };
   const handleDelete = (event: React.MouseEvent, configName: ConfigNameT) => {
-    console.log('DEBUG: Handling delete');
     event.stopPropagation();
     onDeleteConfig(configName);
   };

--- a/client/src/components/common/boost/BoostConfigList.tsx
+++ b/client/src/components/common/boost/BoostConfigList.tsx
@@ -10,7 +10,7 @@ import { removeSuffix } from 'utils/boost';
 export interface BoostConfigListProps {
   config: BoostConfig;
   onSelectConfig: (configName: ConfigNameT) => void;
-  onDeleteConfig: (configName: string) => void;
+  onDeleteConfig: (configName: ConfigNameT) => void;
 }
 
 /**
@@ -27,7 +27,8 @@ export default function BoostConfigList({
   const handleSelect = (configName: ConfigNameT) => {
     if (configName !== config.active) onSelectConfig(configName);
   };
-  const handleDelete = (event: React.MouseEvent, configName: string) => {
+  const handleDelete = (event: React.MouseEvent, configName: ConfigNameT) => {
+    console.log('DEBUG: Handling delete');
     event.stopPropagation();
     onDeleteConfig(configName);
   };
@@ -62,7 +63,7 @@ export default function BoostConfigList({
           <Button
             variant="danger"
             size="sm"
-            onClick={(e) => handleDelete(e, configName.fileName)}
+            onClick={(e) => handleDelete(e, configName)}
           >
             <FontAwesomeIcon icon={faTrashAlt} />
           </Button>

--- a/client/src/components/common/boost/BoostConfigurator.tsx
+++ b/client/src/components/common/boost/BoostConfigurator.tsx
@@ -10,6 +10,7 @@ import {
   FileConfigT,
   ConfigT,
   fileConfigTypeToRuntype,
+  ConfigNameT,
 } from 'types/boost';
 import { camelCaseToStartCase } from 'utils/string';
 import BoostConfigList from 'components/common/boost/BoostConfigList';
@@ -17,7 +18,7 @@ import { Runtype } from 'runtypes';
 
 export interface BoostConfiguratorProps {
   configs: BoostConfig[];
-  onSelectConfig: (configType: ConfigT, name: string) => void;
+  onSelectConfig: (configType: ConfigT, configName: ConfigNameT) => void;
   onDeleteConfig: (configType: ConfigT, name: string) => void;
   onUploadConfig: (
     configType: FileConfigT | 'bundle',
@@ -194,8 +195,8 @@ export default function BoostConfigurator({
                   <Card.Body>
                     <BoostConfigList
                       config={config}
-                      onSelectConfig={(name) =>
-                        onSelectConfig(config.type, name)
+                      onSelectConfig={(configName) =>
+                        onSelectConfig(config.type, configName)
                       }
                       onDeleteConfig={(name) =>
                         setConfirmDeletion({

--- a/client/src/components/common/boost/BoostConfigurator.tsx
+++ b/client/src/components/common/boost/BoostConfigurator.tsx
@@ -19,7 +19,7 @@ import { Runtype } from 'runtypes';
 export interface BoostConfiguratorProps {
   configs: BoostConfig[];
   onSelectConfig: (configType: ConfigT, configName: ConfigNameT) => void;
-  onDeleteConfig: (configType: ConfigT, name: string) => void;
+  onDeleteConfig: (configType: ConfigT, configName: ConfigNameT) => void;
   onUploadConfig: (
     configType: FileConfigT | 'bundle',
     configFile: File,
@@ -45,7 +45,7 @@ export default function BoostConfigurator({
 
   const [confirmDeletion, setConfirmDeletion] = useState({
     show: false,
-    configName: '',
+    configName: { displayName: '', fileName: '' },
     configType: 'rider',
   });
 
@@ -119,7 +119,9 @@ export default function BoostConfigurator({
           </Modal.Title>
         </Modal.Header>
         <Modal.Body>
-          Are you sure you want to delete {confirmDeletion.configName}?
+          Are you sure you want to delete{' '}
+          <i>{confirmDeletion.configName.displayName}</i> (file:{' '}
+          {confirmDeletion.configName.fileName})?
         </Modal.Body>
         <Modal.Footer>
           <Button variant="secondary" onClick={handleConfirmDialogClose}>

--- a/client/src/components/common/boost/BoostConfigurator.tsx
+++ b/client/src/components/common/boost/BoostConfigurator.tsx
@@ -178,18 +178,18 @@ export default function BoostConfigurator({
           <Card.Title style={{ marginBottom: '1.5rem' }}>
             Configuration
             <Button
+              variant="primary"
+              className="mx-3 float-right"
+              onClick={handleGenerate}
+            >
+              Generate
+            </Button>
+            <Button
               variant="outline-primary"
               className="float-right"
               onClick={() => handleClickUpload('bundle')}
             >
               Upload All Configs
-            </Button>
-            <Button
-              variant="outline-primary"
-              className="mx-3 float-right"
-              onClick={handleGenerate}
-            >
-              Generate
             </Button>
           </Card.Title>
           <>

--- a/client/src/components/common/boost/BoostConfigurator.tsx
+++ b/client/src/components/common/boost/BoostConfigurator.tsx
@@ -179,7 +179,7 @@ export default function BoostConfigurator({
             Configuration
             <Button
               variant="primary"
-              className="mx-3 float-right"
+              className="ml-3 float-right"
               onClick={handleGenerate}
             >
               Generate

--- a/client/src/components/common/boost/BoostConfigurator.tsx
+++ b/client/src/components/common/boost/BoostConfigurator.tsx
@@ -114,7 +114,10 @@ export default function BoostConfigurator({
   };
 
   const handlePPGenerationComplete = () => {
-    if (toastId) toast.success('Power plan generated!', { id: toastId });
+    if (toastId) {
+      toast.success('Power plan generated!', { id: toastId });
+      setToastId(null);
+    }
   };
   useChannel('boost/generate_complete', handlePPGenerationComplete);
 

--- a/client/src/components/common/boost/BoostConfigurator.tsx
+++ b/client/src/components/common/boost/BoostConfigurator.tsx
@@ -115,6 +115,7 @@ export default function BoostConfigurator({
 
   const handlePPGenerationComplete = () => {
     if (toastId) {
+      // Update existing loading toast
       toast.success('Power plan generated!', { id: toastId });
       setToastId(null);
     }
@@ -132,11 +133,6 @@ export default function BoostConfigurator({
     if (allConfigsSelected) {
       sendConfigSelections(configs);
       setToastId(toast.loading('Generating power plan...'));
-      // toast.promise(myPromise, {
-      //   loading: 'Generating power plan...',
-      //   success: 'Power Plan Generated',
-      //   error: 'Oops some error occurred',
-      // });
     }
   };
 

--- a/client/src/components/common/boost/BoostConfigurator.tsx
+++ b/client/src/components/common/boost/BoostConfigurator.tsx
@@ -42,10 +42,18 @@ export default function BoostConfigurator({
   const fileInput = createRef<HTMLInputElement>();
   const [configType, setConfigType] = useState<FileConfigT>('bundle');
 
-  const [displayMessage, setDisplayMessage] = useState('');
+  const [confirmDeletion, setConfirmDeletion] = useState({
+    show: false,
+    configName: '',
+    configType: 'rider',
+  });
 
+  const [displayMessage, setDisplayMessage] = useState('');
   const [showUploadErr, setShowUploadErr] = useState(false);
+
   const handleErrorClose = () => setShowUploadErr(false);
+  const handleConfirmDialogClose = () =>
+    setConfirmDeletion({ ...confirmDeletion, show: false });
 
   // Function to click the hidden file input button (this is a work around to avoid the ugly
   // UI of the default input file button)
@@ -92,8 +100,35 @@ export default function BoostConfigurator({
     }
   };
 
+  const handleDelete = () => {
+    onDeleteConfig(
+      confirmDeletion.configType as ConfigT,
+      confirmDeletion.configName,
+    );
+    handleConfirmDialogClose();
+  };
+
   return (
     <>
+      <Modal show={confirmDeletion.show} onHide={handleConfirmDialogClose}>
+        <Modal.Header closeButton>
+          <Modal.Title>
+            <FontAwesomeIcon icon={faExclamationTriangle} />
+            <b className="mx-3"> Confirm Deletion</b>
+          </Modal.Title>
+        </Modal.Header>
+        <Modal.Body>
+          Are you sure you want to delete {confirmDeletion.configName}?
+        </Modal.Body>
+        <Modal.Footer>
+          <Button variant="secondary" onClick={handleConfirmDialogClose}>
+            No
+          </Button>
+          <Button variant="danger" onClick={handleDelete}>
+            Yes
+          </Button>
+        </Modal.Footer>
+      </Modal>
       <Modal show={showUploadErr} onHide={handleErrorClose}>
         <Modal.Header closeButton>
           <Modal.Title>
@@ -163,7 +198,11 @@ export default function BoostConfigurator({
                         onSelectConfig(config.type, name)
                       }
                       onDeleteConfig={(name) =>
-                        onDeleteConfig(config.type, name)
+                        setConfirmDeletion({
+                          show: true,
+                          configName: name,
+                          configType: config.type,
+                        })
                       }
                     />
                   </Card.Body>

--- a/client/src/types/boost.ts
+++ b/client/src/types/boost.ts
@@ -103,7 +103,7 @@ export const ConfigNameRT = Record({
   displayName: String,
   fileName: String,
 });
-type ConfigNameT = Static<typeof ConfigNameRT>;
+export type ConfigNameT = Static<typeof ConfigNameRT>;
 
 // Type of the payload on 'boost/configs'
 export const ConfigPayloadRT = Record({
@@ -130,3 +130,5 @@ export const fileConfigTypeToRuntype: ConfigDictionaryT = {
   powerPlan: PowerPlanRT,
   bundle: ConfigBundleRT,
 };
+
+export type SelectedConfigsT = { [key in ConfigT]: string | undefined };

--- a/client/src/views/common/BoostView.tsx
+++ b/client/src/views/common/BoostView.tsx
@@ -24,7 +24,6 @@ import { ReedDistanceRT } from 'types/data';
  */
 export default function BoostView() {
   const [distOffset, setDistOffset] = useState<number | null>(null);
-  const [numConfigsSelected, setConfigsSelected] = useState(0);
 
   const [configs, setConfigs] = useState<BoostConfig[]>([
     {
@@ -86,9 +85,6 @@ export default function BoostView() {
     setConfigs(
       configs.map((config) => {
         if (config.type === configType) {
-          if (!config.active) {
-            setConfigsSelected(numConfigsSelected + 1);
-          }
           return { ...config, active: configName };
         }
         return config;

--- a/client/src/views/common/BoostView.tsx
+++ b/client/src/views/common/BoostView.tsx
@@ -3,7 +3,7 @@ import ContentPage from 'components/common/ContentPage';
 import BoostCalibration from 'components/common/boost/BoostCalibration';
 import BoostConfigurator from 'components/common/boost/BoostConfigurator';
 import { setCalibration, resetCalibration } from 'api/common/powerModel';
-import uploadConfig, { deleteConfig, sendConfigSelections } from 'api/v3/boost';
+import uploadConfig, { deleteConfig } from 'api/v3/boost';
 import {
   ConfigT,
   BoostConfig,
@@ -13,7 +13,7 @@ import {
 } from 'types/boost';
 import { useSensorData, Sensor } from 'api/common/data';
 import { Static } from 'runtypes';
-import { useChannelShaped, useChannel } from 'api/common/socket';
+import { useChannelShaped } from 'api/common/socket';
 import toast from 'react-hot-toast';
 import { ReedDistanceRT } from 'types/data';
 
@@ -26,8 +26,8 @@ export default function BoostView() {
   const [distOffset, setDistOffset] = useState<number | null>(null);
   const [numConfigsSelected, setConfigsSelected] = useState(0);
 
-  // Keeps track of whether a power plan is being generated or not
-  const [powerPlanGenerating, setPowerPlanGenerating] = useState(false);
+  // // Keeps track of whether a power plan is being generated or not
+  // const [powerPlanGenerating, setPowerPlanGenerating] = useState(false);
   const [configs, setConfigs] = useState<BoostConfig[]>([
     {
       type: 'powerPlan',
@@ -77,15 +77,15 @@ export default function BoostView() {
     handleDistOffsetReceived,
   );
 
-  const handlePPGenerationComplete = () => {
-    if (powerPlanGenerating) {
-      setPowerPlanGenerating(false);
-      toast.dismiss();
-      toast.success('Power Plan Generated!');
-    }
-  };
+  // const handlePPGenerationComplete = () => {
+  //   if (powerPlanGenerating) {
+  //     setPowerPlanGenerating(false);
+  //     toast.dismiss();
+  //     toast.success('Power Plan Generated!');
+  //   }
+  // };
 
-  useChannel('boost/generate_complete', handlePPGenerationComplete);
+  // useChannel('boost/generate_complete', handlePPGenerationComplete);
 
   const handleReset = () => {
     setDistOffset(0);
@@ -94,6 +94,7 @@ export default function BoostView() {
   };
 
   const handleSelect = (configType: ConfigT, configName: ConfigNameT) => {
+    // Update the active field of the selected config in `configs`
     setConfigs(
       configs.map((config) => {
         if (config.type === configType) {
@@ -105,12 +106,6 @@ export default function BoostView() {
         return config;
       }),
     );
-    if (numConfigsSelected >= 3) {
-      // All config types selected, ready to generate power plan!
-      sendConfigSelections(configs, configType, configName);
-      setPowerPlanGenerating(true);
-      toast.loading('Generating power plan...');
-    }
   };
 
   return (

--- a/client/src/views/common/BoostView.tsx
+++ b/client/src/views/common/BoostView.tsx
@@ -3,7 +3,7 @@ import ContentPage from 'components/common/ContentPage';
 import BoostCalibration from 'components/common/boost/BoostCalibration';
 import BoostConfigurator from 'components/common/boost/BoostConfigurator';
 import { setCalibration, resetCalibration } from 'api/common/powerModel';
-import uploadConfig from 'api/v3/boost';
+import uploadConfig, { deleteConfig } from 'api/v3/boost';
 import {
   ConfigT,
   BoostConfig,
@@ -26,18 +26,6 @@ import { ReedDistanceRT } from 'types/data';
  */
 function onSelectConfig(configType: ConfigT, name: string) {
   console.log('Selected config:');
-  console.log(`type: ${configType}`);
-  console.log(`name: ${name}`);
-}
-
-/**
- * Inform boost of the deletion of the given config file
- *
- * @param configType the type of the config
- * @param name name of the config file
- */
-function onDeleteConfig(configType: ConfigT, name: string) {
-  console.log('Deleted config:');
   console.log(`type: ${configType}`);
   console.log(`name: ${name}`);
 }
@@ -115,7 +103,7 @@ export default function BoostView() {
       <BoostConfigurator
         configs={configs}
         onSelectConfig={onSelectConfig}
-        onDeleteConfig={onDeleteConfig}
+        onDeleteConfig={deleteConfig}
         onUploadConfig={uploadConfig}
       />
     </ContentPage>

--- a/server/js/sockets.js
+++ b/server/js/sockets.js
@@ -99,6 +99,7 @@ sockets.init = function socketInit(server) {
   mqttClient.subscribe(DAS.data);
   mqttClient.subscribe(WirelessModule.all().module);
   mqttClient.subscribe(BOOST.predicted_max_speed);
+  mqttClient.subscribe(BOOST.generate_complete);
   mqttClient.subscribe(BOOST.recommended_sp);
   mqttClient.subscribe(BOOST.configs);
   mqttClient.subscribe(Camera.push_overlays);
@@ -209,6 +210,9 @@ sockets.init = function socketInit(server) {
           case BOOST.configs:
             socket.emit('boost/configs', payloadString);
             break;
+          case BOOST.generate_complete:
+            socket.emit('boost/generate_complete', payloadString);
+              break;
           // TODO: Remove this when handling of
           // BOOST.generate.complete is implemented.
           case 'power_model/plan_generated':
@@ -250,6 +254,10 @@ sockets.init = function socketInit(server) {
 
     socket.on('send-config', (configContent) => {
       mqttClient.publish('boost/configs/action', configContent);
+    });
+
+    socket.on('submit-selected-configs', (selectedConfigs) => {
+      mqttClient.publish(BOOST.generate, selectedConfigs);
     });
 
     socket.on('submit-calibration', (calibratedDistance) => {


### PR DESCRIPTION
## Description

This PR is the last of the series of PR adding logic to the boost page. This one adds the ability to select a config file from the display and use the `generate` button to inform boost to generate a power plan from the selected configs. The user is shown a 'generating power plan...' toast and updates it when `boost` responds with the power plan completed. 

Users can also delete a config (there is a confirm box for this action) and here lies a big design workaround. To improve the user experience, I have decided to remove the deleted config immediately from the display instead of waiting for `boost` to confirm that it has received the deletion notification. This introduces the risk of `dashboard` and `boost` diverging in their state, usually this divergence will be for a small period of time and will resolve when boost is informed of the deletion. However, if an error occurs and `boost` backend doesn't update it's data upon deletion in the front-end then our stack will be misaligned. Let me know of your thoughts on this!

## Screenshots
**Error when not all configs are selected and the 'generate' button is clicked:**
<img width="779" alt="Screen Shot 2021-04-11 at 1 51 12 pm" src="https://user-images.githubusercontent.com/63642262/114293975-2dfe7480-9ade-11eb-956b-2a6e569f50cb.png">

**'Loading' toast when power plan is being generated:**
<img width="817" alt="Screen Shot 2021-04-11 at 1 51 26 pm" src="https://user-images.githubusercontent.com/63642262/114294097-4753f080-9adf-11eb-9e3b-9383607b52a6.png">

**Confirm dialog box when deleting:**
<img width="835" alt="Screen Shot 2021-04-11 at 1 51 00 pm" src="https://user-images.githubusercontent.com/63642262/114293998-51c1ba80-9ade-11eb-8382-96231a805544.png">


## Steps to Test

1) Run the client and server
2) Initially there would be no configs, use 
```
mosquitto_pub -h localhost -t 'boost/configs' -m '{"rider": [{"displayName": "Default rider", "fileName": "default.json"}], "track": [{"displayName": "Holden", "fileName": "holden.json"}, {"displayName": "Ford", "fileName": "ford.json"}, {"displayName": "Battle Mountain", "fileName": "bm.json"}], "bike": [{"displayName": "Wombat", "fileName": "v2.json"}, {"displayName": "Wombat", "fileName": "v2_old_camera.json"}, {"displayName": "Priscilla", "fileName": "v3.json"}, {"displayName": "Blacksmith", "fileName": "v1.5.json"}], "powerPlan": [{"displayName": "test", "fileName": "test.json"}, {"displayName": "default", "fileName": "default.json"}]}'
```
to add the configs
3) Try selecting a config
4) Attempt to generate power plan with the `generate` button without selecting all configs to check that the error is handled
5) Select config for each type and generate the power plan, subsequently use
```
mosquitto_pub -h localhost -t 'boost/generate_complete' -m " "
```
to inform dashboard that the power plan has been generated. (The payload is a simple empty string only for testing purposes, the actual payload is irrelevant for `dashboard` at the moment)
6) Finally, try deleting a config and see if it works!

