### PR TITLE
Patch Camera Settings Page

### DIFF
--- a/client/src/components/common/camera_settings/CameraStatus.tsx
+++ b/client/src/components/common/camera_settings/CameraStatus.tsx
@@ -9,11 +9,7 @@ export interface CameraStatusProps {
 }
 
 /**
- * Camera recording buttons for starting and stopping video recording.
- *
- * Starts/stops recording for both displays.
- *
- * This is a feature intended for V3 but is currently in V2 for testing.
+ * Status of Cameras
  *
  * @param props Props
  * @returns Component


### PR DESCRIPTION
## Description

Camera settings was broken because of my dodgy and hard to use API. This is a patch for that in the mean time before I refactor it.

The Camera Status card is linked to the `status/camera/<primary/secondary>` topic but it seems like that hasn't been implemented (?) yet on raspicam.

## Screenshots

![image](https://user-images.githubusercontent.com/50545432/117540030-93e40a80-b050-11eb-94ef-b6915ad60499.png)

## Steps to Test

1. Start dashboard client and server, and mosquitto
2. Start raspicam with `overlay_new.py`
