### PR TITLE
Display Results calculated by BOOST

### DIFF
--- a/client/src/api/v3/boost.ts
+++ b/client/src/api/v3/boost.ts
@@ -102,7 +102,7 @@ export function sendConfigSelections(configs: BoostConfig[]) {
 
   // Populate payload with the currently active config for each config type
   configs.forEach((config) => {
-    payload[config.type] = config.active?.displayName;
+    payload[config.type] = config.active?.fileName;
   });
   // Send selected configs to generate Power Plan
   emit('submit-selected-configs', JSON.stringify(payload));

--- a/client/src/components/common/boost/BoostConfigurator.tsx
+++ b/client/src/components/common/boost/BoostConfigurator.tsx
@@ -50,7 +50,7 @@ export default function BoostConfigurator({
   const [configType, setConfigType] = useState<FileConfigT>('bundle');
   const [toastId, setToastId] = useState<string | null>(null);
 
-  const [boostResult, setBoostResult] = useState<BoostResultsT | null>(null);
+  const [boostResults, setBoostResults] = useState<BoostResultsT | null>(null);
 
   const [confirmDeletion, setConfirmDeletion] = useState({
     show: false,
@@ -124,7 +124,7 @@ export default function BoostConfigurator({
       toast.success('Power plan generated!', { id: toastId });
       setToastId(null);
     }
-    setBoostResult(results);
+    setBoostResults(results);
   };
   useChannelShaped(
     'boost/generate_complete',
@@ -201,7 +201,6 @@ export default function BoostConfigurator({
             >
               Upload All Configs
             </Button>
-            <BoostResults results={boostResult} />
           </Card.Title>
           <>
             <input
@@ -258,6 +257,24 @@ export default function BoostConfigurator({
                 </Accordion.Collapse>
               </Card>
             ))}
+          </Accordion>
+          <Accordion className="small p-0 my-4">
+            <Card>
+              <Accordion.Toggle
+                className="p-2"
+                eventKey="0"
+                variant="outline-primary"
+                as={Button}
+                style={{ cursor: 'pointer' }}
+              >
+                View Plan
+              </Accordion.Toggle>
+              <Accordion.Collapse eventKey="0">
+                <Card.Body>
+                  <BoostResults results={boostResults} />
+                </Card.Body>
+              </Accordion.Collapse>
+            </Card>
           </Accordion>
         </Card.Body>
       </Card>

--- a/client/src/components/common/boost/BoostConfigurator.tsx
+++ b/client/src/components/common/boost/BoostConfigurator.tsx
@@ -11,12 +11,12 @@ import {
   ConfigT,
   fileConfigTypeToRuntype,
   ConfigNameT,
-  BoostResultT,
-  BoostResultRT,
+  BoostResultsT,
+  BoostResultsRT,
 } from 'types/boost';
 import { camelCaseToStartCase } from 'utils/string';
 import BoostConfigList from 'components/common/boost/BoostConfigList';
-import BoostResult from 'components/common/boost/BoostResults';
+import BoostResults from 'components/common/boost/BoostResults';
 import { Runtype } from 'runtypes';
 import { sendConfigSelections } from 'api/v3/boost';
 import toast from 'react-hot-toast';
@@ -50,7 +50,7 @@ export default function BoostConfigurator({
   const [configType, setConfigType] = useState<FileConfigT>('bundle');
   const [toastId, setToastId] = useState<string | null>(null);
 
-  const [boostResult, setBoostResult] = useState<BoostResultT | null>(null);
+  const [boostResult, setBoostResult] = useState<BoostResultsT | null>(null);
 
   const [confirmDeletion, setConfirmDeletion] = useState({
     show: false,
@@ -118,7 +118,7 @@ export default function BoostConfigurator({
     handleConfirmDialogClose();
   };
 
-  const handlePPGenerationComplete = (results: BoostResultT) => {
+  const handlePPGenerationComplete = (results: BoostResultsT) => {
     if (toastId) {
       // Update existing loading toast
       toast.success('Power plan generated!', { id: toastId });
@@ -128,7 +128,7 @@ export default function BoostConfigurator({
   };
   useChannelShaped(
     'boost/generate_complete',
-    BoostResultRT,
+    BoostResultsRT,
     handlePPGenerationComplete,
   );
 
@@ -201,7 +201,7 @@ export default function BoostConfigurator({
             >
               Upload All Configs
             </Button>
-            <BoostResult results={boostResult} />
+            <BoostResults results={boostResult} />
           </Card.Title>
           <>
             <input

--- a/client/src/components/common/boost/BoostConfigurator.tsx
+++ b/client/src/components/common/boost/BoostConfigurator.tsx
@@ -219,6 +219,7 @@ export default function BoostConfigurator({
                 <Accordion.Toggle
                   as={Card.Header}
                   variant="link"
+                  style={{ cursor: 'pointer' }}
                   eventKey={String(index)}
                 >
                   {camelCaseToStartCase(config.type)}

--- a/client/src/components/common/boost/BoostConfigurator.tsx
+++ b/client/src/components/common/boost/BoostConfigurator.tsx
@@ -11,13 +11,16 @@ import {
   ConfigT,
   fileConfigTypeToRuntype,
   ConfigNameT,
+  BoostResultT,
+  BoostResultRT,
 } from 'types/boost';
 import { camelCaseToStartCase } from 'utils/string';
 import BoostConfigList from 'components/common/boost/BoostConfigList';
+import BoostResult from 'components/common/boost/BoostResults';
 import { Runtype } from 'runtypes';
 import { sendConfigSelections } from 'api/v3/boost';
 import toast from 'react-hot-toast';
-import { useChannel } from 'api/common/socket';
+import { useChannelShaped } from 'api/common/socket';
 
 export interface BoostConfiguratorProps {
   configs: BoostConfig[];
@@ -46,6 +49,8 @@ export default function BoostConfigurator({
   const fileInput = createRef<HTMLInputElement>();
   const [configType, setConfigType] = useState<FileConfigT>('bundle');
   const [toastId, setToastId] = useState<string | null>(null);
+
+  const [boostResult, setBoostResult] = useState<BoostResultT | null>(null);
 
   const [confirmDeletion, setConfirmDeletion] = useState({
     show: false,
@@ -113,14 +118,19 @@ export default function BoostConfigurator({
     handleConfirmDialogClose();
   };
 
-  const handlePPGenerationComplete = () => {
+  const handlePPGenerationComplete = (results: BoostResultT) => {
     if (toastId) {
       // Update existing loading toast
       toast.success('Power plan generated!', { id: toastId });
       setToastId(null);
     }
+    setBoostResult(results);
   };
-  useChannel('boost/generate_complete', handlePPGenerationComplete);
+  useChannelShaped(
+    'boost/generate_complete',
+    BoostResultRT,
+    handlePPGenerationComplete,
+  );
 
   const handleGenerate = () => {
     let allConfigsSelected = true;
@@ -191,6 +201,7 @@ export default function BoostConfigurator({
             >
               Upload All Configs
             </Button>
+            <BoostResult results={boostResult} />
           </Card.Title>
           <>
             <input

--- a/client/src/components/common/boost/BoostConfigurator.tsx
+++ b/client/src/components/common/boost/BoostConfigurator.tsx
@@ -258,24 +258,7 @@ export default function BoostConfigurator({
               </Card>
             ))}
           </Accordion>
-          <Accordion className="small p-0 my-4">
-            <Card>
-              <Accordion.Toggle
-                className="p-2"
-                eventKey="0"
-                variant="outline-primary"
-                as={Button}
-                style={{ cursor: 'pointer' }}
-              >
-                View Plan
-              </Accordion.Toggle>
-              <Accordion.Collapse eventKey="0">
-                <Card.Body>
-                  <BoostResults results={boostResults} />
-                </Card.Body>
-              </Accordion.Collapse>
-            </Card>
-          </Accordion>
+          {boostResults ? <BoostResults results={boostResults} /> : null}
         </Card.Body>
       </Card>
     </>

--- a/client/src/components/common/boost/BoostResults.stories.tsx
+++ b/client/src/components/common/boost/BoostResults.stories.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { addArgs, createStory } from 'utils/stories';
+import { BoostResultT } from 'types/boost';
+import BoostResults, {
+  BoostResultProps,
+} from 'components/common/boost/BoostResults';
+
+export default {
+  title: 'components/common/boost/BoostResults',
+  component: BoostResults,
+};
+
+const Template = addArgs<BoostResultProps>((props) => (
+  <BoostResults {...props} />
+));
+
+const exampleResults: BoostResultT = {
+  fileName: 'example-File-Name',
+  maxSpeed: 25,
+  zones: [
+    {
+      power: 20,
+      distance: 25,
+    },
+    {
+      power: 30,
+      distance: 40,
+    },
+  ],
+};
+
+export const Simple = createStory(Template, {
+  results: exampleResults,
+});
+
+export const NoPlan = createStory(Template, {
+  results: null,
+});

--- a/client/src/components/common/boost/BoostResults.stories.tsx
+++ b/client/src/components/common/boost/BoostResults.stories.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { addArgs, createStory } from 'utils/stories';
-import { BoostResultT } from 'types/boost';
+import { BoostResultsT } from 'types/boost';
 import BoostResults, {
-  BoostResultProps,
+  BoostResultsProps,
 } from 'components/common/boost/BoostResults';
 
 export default {
@@ -10,17 +10,17 @@ export default {
   component: BoostResults,
 };
 
-const Template = addArgs<BoostResultProps>((props) => (
+const Template = addArgs<BoostResultsProps>((props) => (
   <BoostResults {...props} />
 ));
 
-const exampleResults: BoostResultT = {
+const exampleResults: BoostResultsT = {
   fileName: 'example-File-Name',
   maxSpeed: 25,
   zones: [
     {
-      power: 20,
-      distance: 25,
+      power: 20.33,
+      distance: 25.1,
     },
     {
       power: 30,

--- a/client/src/components/common/boost/BoostResults.tsx
+++ b/client/src/components/common/boost/BoostResults.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { BoostResultT } from 'types/boost';
+import { Card, Accordion, Table } from 'react-bootstrap';
+
+export interface BoostResultProps {
+  results: BoostResultT | null;
+}
+
+/**
+ * Displays the Maximum achievable speed and the power plan (the distance and the associated recommended power)
+ *
+ * @param props BoostResultProps
+ * @returns JSX Element
+ */
+export default function BoostResult(props: BoostResultProps) {
+  const { results } = props;
+
+  return (
+    <Card className="mt-4">
+      <Card.Body>
+        <Card.Title className="small">
+          <b>BOOST Output:</b>
+        </Card.Title>
+        <div className="small pb-3">
+          Maximum Speed
+          <span className="float-right pr-4">
+            {results ? `${results.maxSpeed} km/h` : 'N/A'}
+          </span>
+        </div>
+        <Accordion className="small p-0">
+          <Card>
+            <Accordion.Toggle className="p-2" eventKey="0" as={Card.Header}>
+              View plan{' '}
+              <i className="small">{results ? `(${results.fileName})` : ''}</i>
+            </Accordion.Toggle>
+            <Accordion.Collapse eventKey="0">
+              <Card.Body>
+                <Table striped bordered hover size="sm">
+                  <thead>
+                    <tr>
+                      <th>Distance (m)</th>
+                      <th>Power (W)</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {results?.zones.map((value) => {
+                      return (
+                        <tr>
+                          <td>{value.distance}</td>
+                          <td>{value.power}</td>
+                        </tr>
+                      );
+                    })}
+                  </tbody>
+                </Table>
+              </Card.Body>
+            </Accordion.Collapse>
+          </Card>
+        </Accordion>
+      </Card.Body>
+    </Card>
+  );
+}

--- a/client/src/components/common/boost/BoostResults.tsx
+++ b/client/src/components/common/boost/BoostResults.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { BoostResultsT } from 'types/boost';
-import { Table } from 'react-bootstrap';
+import { Table, Accordion, Button, Card } from 'react-bootstrap';
 
 export interface BoostResultsProps {
   results: BoostResultsT | null;
@@ -16,45 +16,58 @@ export default function BoostResults(props: BoostResultsProps) {
   const { results } = props;
   const speedPrecision = 2;
 
-  if (!results) {
-    return <div>No Power Plan Profile Generated Yet...</div>;
-  }
-
   return (
     <>
-      <div className="ml-2">
-        <b>Max Speed: </b>
-        <span className="float-right">
-          {' '}
-          {results
-            ? `${results.maxSpeed.toFixed(speedPrecision)} km/h`
-            : 'N/A'}{' '}
-        </span>
-      </div>
-      <div className="my-2 ml-2">
-        <b>File name:</b>
-        <i className="small float-right">
-          {results ? `(${results.fileName})` : ''}
-        </i>
-      </div>
-      <Table striped bordered hover size="sm m-1">
-        <thead>
-          <tr>
-            <th>Distance (m)</th>
-            <th>Power (W)</th>
-          </tr>
-        </thead>
-        <tbody>
-          {results?.zones.map((value) => {
-            return (
-              <tr>
-                <td>{Math.round(value.distance)}</td>
-                <td>{Math.round(value.power)}</td>
-              </tr>
-            );
-          })}
-        </tbody>
-      </Table>
+      <Accordion className="small p-0 my-4">
+        <Card>
+          <Accordion.Toggle
+            className="p-2"
+            eventKey="0"
+            variant="outline-primary"
+            as={Button}
+            style={{ cursor: 'pointer' }}
+          >
+            View Plan
+          </Accordion.Toggle>
+          <Accordion.Collapse eventKey="0">
+            <Card.Body>
+              <div className="ml-2">
+                <b>Max Speed: </b>
+                <span className="float-right">
+                  {' '}
+                  {results
+                    ? `${results.maxSpeed.toFixed(speedPrecision)} km/h`
+                    : 'N/A'}{' '}
+                </span>
+              </div>
+              <div className="my-2 ml-2">
+                <b>File name:</b>
+                <i className="small float-right">
+                  {results ? `(${results.fileName})` : ''}
+                </i>
+              </div>
+              <Table striped bordered hover size="sm m-1">
+                <thead>
+                  <tr>
+                    <th>Distance (m)</th>
+                    <th>Power (W)</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {results?.zones.map((value) => {
+                    return (
+                      <tr>
+                        <td>{Math.round(value.distance)}</td>
+                        <td>{Math.round(value.power)}</td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </Table>
+            </Card.Body>
+          </Accordion.Collapse>
+        </Card>
+      </Accordion>
     </>
   );
 }

--- a/client/src/components/common/boost/BoostResults.tsx
+++ b/client/src/components/common/boost/BoostResults.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { BoostResultsT } from 'types/boost';
-import { Card, Accordion, Table } from 'react-bootstrap';
+import { Table } from 'react-bootstrap';
 
 export interface BoostResultsProps {
   results: BoostResultsT | null;
@@ -16,56 +16,45 @@ export default function BoostResults(props: BoostResultsProps) {
   const { results } = props;
   const speedPrecision = 2;
 
+  if (!results) {
+    return <div>No Power Plan Profile Generated Yet...</div>;
+  }
+
   return (
-    <Card className="mt-4">
-      <Card.Body>
-        <Card.Title className="small">
-          <b>BOOST Output</b>
-        </Card.Title>
-        <div className="small pb-3">
-          Maximum Speed
-          <span className="float-right pr-4">
-            {results
-              ? `${results.maxSpeed.toFixed(speedPrecision)} km/h`
-              : 'N/A'}
-          </span>
-        </div>
-        <Accordion className="small p-0">
-          <Card>
-            <Accordion.Toggle
-              className="p-2"
-              eventKey="0"
-              as={Card.Header}
-              style={{ cursor: 'pointer' }}
-            >
-              View plan{' '}
-              <i className="small">{results ? `(${results.fileName})` : ''}</i>
-            </Accordion.Toggle>
-            <Accordion.Collapse eventKey="0">
-              <Card.Body>
-                <Table striped bordered hover size="sm">
-                  <thead>
-                    <tr>
-                      <th>Distance (m)</th>
-                      <th>Power (W)</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {results?.zones.map((value) => {
-                      return (
-                        <tr>
-                          <td>{Math.round(value.distance)}</td>
-                          <td>{Math.round(value.power)}</td>
-                        </tr>
-                      );
-                    })}
-                  </tbody>
-                </Table>
-              </Card.Body>
-            </Accordion.Collapse>
-          </Card>
-        </Accordion>
-      </Card.Body>
-    </Card>
+    <>
+      <div className="ml-2">
+        Max Speed:
+        <span className="float-right">
+          {' '}
+          {results
+            ? `${results.maxSpeed.toFixed(speedPrecision)} km/h`
+            : 'N/A'}{' '}
+        </span>
+      </div>
+      <div className="my-2 ml-2">
+        File name:{' '}
+        <i className="small float-right">
+          {results ? `(${results.fileName})` : ''}
+        </i>
+      </div>
+      <Table striped bordered hover size="sm m-1">
+        <thead>
+          <tr>
+            <th>Distance (m)</th>
+            <th>Power (W)</th>
+          </tr>
+        </thead>
+        <tbody>
+          {results?.zones.map((value) => {
+            return (
+              <tr>
+                <td>{Math.round(value.distance)}</td>
+                <td>{Math.round(value.power)}</td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </Table>
+    </>
   );
 }

--- a/client/src/components/common/boost/BoostResults.tsx
+++ b/client/src/components/common/boost/BoostResults.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
-import { BoostResultT } from 'types/boost';
+import { BoostResultsT } from 'types/boost';
 import { Card, Accordion, Table } from 'react-bootstrap';
 
-export interface BoostResultProps {
-  results: BoostResultT | null;
+export interface BoostResultsProps {
+  results: BoostResultsT | null;
 }
 
 /**
@@ -12,19 +12,22 @@ export interface BoostResultProps {
  * @param props BoostResultProps
  * @returns JSX Element
  */
-export default function BoostResult(props: BoostResultProps) {
+export default function BoostResults(props: BoostResultsProps) {
   const { results } = props;
+  const speedPrecision = 2;
 
   return (
     <Card className="mt-4">
       <Card.Body>
         <Card.Title className="small">
-          <b>BOOST Output:</b>
+          <b>BOOST Output</b>
         </Card.Title>
         <div className="small pb-3">
           Maximum Speed
           <span className="float-right pr-4">
-            {results ? `${results.maxSpeed} km/h` : 'N/A'}
+            {results
+              ? `${results.maxSpeed.toFixed(speedPrecision)} km/h`
+              : 'N/A'}
           </span>
         </div>
         <Accordion className="small p-0">
@@ -51,8 +54,8 @@ export default function BoostResult(props: BoostResultProps) {
                     {results?.zones.map((value) => {
                       return (
                         <tr>
-                          <td>{value.distance}</td>
-                          <td>{value.power}</td>
+                          <td>{Math.round(value.distance)}</td>
+                          <td>{Math.round(value.power)}</td>
                         </tr>
                       );
                     })}

--- a/client/src/components/common/boost/BoostResults.tsx
+++ b/client/src/components/common/boost/BoostResults.tsx
@@ -23,7 +23,7 @@ export default function BoostResults(props: BoostResultsProps) {
   return (
     <>
       <div className="ml-2">
-        Max Speed:
+        <b>Max Speed: </b>
         <span className="float-right">
           {' '}
           {results
@@ -32,7 +32,7 @@ export default function BoostResults(props: BoostResultsProps) {
         </span>
       </div>
       <div className="my-2 ml-2">
-        File name:{' '}
+        <b>File name:</b>
         <i className="small float-right">
           {results ? `(${results.fileName})` : ''}
         </i>

--- a/client/src/components/common/boost/BoostResults.tsx
+++ b/client/src/components/common/boost/BoostResults.tsx
@@ -29,7 +29,12 @@ export default function BoostResult(props: BoostResultProps) {
         </div>
         <Accordion className="small p-0">
           <Card>
-            <Accordion.Toggle className="p-2" eventKey="0" as={Card.Header}>
+            <Accordion.Toggle
+              className="p-2"
+              eventKey="0"
+              as={Card.Header}
+              style={{ cursor: 'pointer' }}
+            >
               View plan{' '}
               <i className="small">{results ? `(${results.fileName})` : ''}</i>
             </Accordion.Toggle>

--- a/client/src/types/boost.ts
+++ b/client/src/types/boost.ts
@@ -132,3 +132,11 @@ export const fileConfigTypeToRuntype: ConfigDictionaryT = {
 };
 
 export type SelectedConfigsT = { [key in ConfigT]: string | undefined };
+
+const ZoneDistanceRT = Record({ power: Number, distance: Number });
+export const BoostResultRT = Record({
+  fileName: String,
+  maxSpeed: Number,
+  zones: Array(ZoneDistanceRT),
+});
+export type BoostResultT = Static<typeof BoostResultRT>;

--- a/client/src/types/boost.ts
+++ b/client/src/types/boost.ts
@@ -134,9 +134,9 @@ export const fileConfigTypeToRuntype: ConfigDictionaryT = {
 export type SelectedConfigsT = { [key in ConfigT]: string | undefined };
 
 const ZoneDistanceRT = Record({ power: Number, distance: Number });
-export const BoostResultRT = Record({
+export const BoostResultsRT = Record({
   fileName: String,
   maxSpeed: Number,
   zones: Array(ZoneDistanceRT),
 });
-export type BoostResultT = Static<typeof BoostResultRT>;
+export type BoostResultsT = Static<typeof BoostResultsRT>;

--- a/server/js/topics.js
+++ b/server/js/topics.js
@@ -18,7 +18,7 @@ class BOOST {
 
   // Plan generation
   static generate = 'boost/generate';
-  static generate_complete = 'boost/generate_complete';
+  static generate_complete = 'boost/generate/complete';
 
   // Distance calibration
   static calibrate = 'boost/calibrate';


### PR DESCRIPTION
## Description

This PR adds a UI component `BoostResult` to display the output from BOOST when a power plan is generated. This includes the maximum achievable speed and the zone distance and recommend power in that zone to achieve the max speed.

## Screenshots

When no power plan generated:
<img width="1173" alt="Screen Shot 2021-07-17 at 9 10 47 pm" src="https://user-images.githubusercontent.com/63642262/126035378-33ad9850-ba18-4f1c-bd6d-d36d8d556036.png">


When power plan generated:
<img width="1165" alt="Screen Shot 2021-07-17 at 9 11 17 pm" src="https://user-images.githubusercontent.com/63642262/126035394-eb8a194f-72c3-429c-b141-385ad12d0021.png">


## Steps to Test

1) Run both client and server
1.5) You may need to run
```
mosquitto_pub -t "boost/configs" -h localhost -m '{"rider": [{"displayName": "Default rider", "fileName": "default_rider.json"}], "track": [{"displayName": "Ford", "fileName": "ford.json"}, {"displayName": "Holden", "fileName": "holden.json"}, {"displayName": "Battle Mountain", "fileName": "bm.json"}], "bike": [{"displayName": "Wombat", "fileName": "v2_old_camera.json"}, {"displayName": "Blacksmith", "fileName": "v1.5.json"}, {"displayName": "Wombat", "fileName": "v2.json"}, {"displayName": "Priscilla", "fileName": "v3.json"}], "powerPlan": [{"displayName": "test", "fileName": "test.json"}, {"displayName": "default", "fileName": "default.json"}]}'
```
to populate the configs on the Dashboard to use the `generate` button.

2) Use another terminal and publish to `boost/generate_complete` topic. Shortcut:
```
mosquitto_pub -t 'boost/generate_complete' -h localhost -m "{\"fileName\":\"example-File-Name2\",\"maxSpeed\":25,\"zones\":[{\"power\":20,\"distance\":25},{\"power\":30,\"distance\":40}]}"
```
3) Watch the results displayed to the UI
