### PR TITLE
Make DAShboard start/stop control BOOST

### DIFF
--- a/client/src/api/common/data.ts
+++ b/client/src/api/common/data.ts
@@ -147,3 +147,18 @@ export function startLogging() {
 export function stopLogging() {
   emit('stop-das-recording');
 }
+
+/**
+ * Start Boosting
+ */
+export function startBoosting(){
+  emit('start-boost');
+  
+}
+
+/**
+ * Stop Boosting
+ */
+export function stopBoosting(){
+  emit('stop-boost');
+}

--- a/client/src/api/common/data.ts
+++ b/client/src/api/common/data.ts
@@ -151,14 +151,13 @@ export function stopLogging() {
 /**
  * Start Boosting
  */
-export function startBoosting(){
-  emit('start-boost');
-  
+export function startBoost(){
+  emit('start-boost'); 
 }
 
 /**
  * Stop Boosting
  */
-export function stopBoosting(){
+export function stopBoost(){
   emit('stop-boost');
 }

--- a/client/src/components/v3/DASRecording.tsx
+++ b/client/src/components/v3/DASRecording.tsx
@@ -1,4 +1,4 @@
-import { startLogging, stopLogging, startBoosting, stopBoosting } from 'api/common/data';
+import { startLogging, stopLogging, startBoost, stopBoost } from 'api/common/data';
 import React from 'react';
 import { Button } from 'react-bootstrap';
 
@@ -12,10 +12,10 @@ export default function DASRecording(): JSX.Element {
   return (
     <>
       <span style={{ fontWeight: 'bold' }}>DAS Recording:</span>
-      <Button className="ml-3" variant="outline-success" onClick={() => {startLogging(); startBoosting();}}>
+      <Button className="ml-3" variant="outline-success" onClick={() => {startLogging(); startBoost();}}>
         Start
       </Button>
-      <Button className="ml-2" variant="outline-danger" onClick={() => {stopLogging(); stopBoosting();}}>
+      <Button className="ml-2" variant="outline-danger" onClick={() => {stopLogging(); stopBoost();}}>
         Stop
       </Button>
     </>

--- a/client/src/components/v3/DASRecording.tsx
+++ b/client/src/components/v3/DASRecording.tsx
@@ -1,5 +1,4 @@
-import { startLogging, stopLogging } from 'api/common/data';
-import { emit } from 'api/common/socket';
+import { startLogging, stopLogging, startBoosting, stopBoosting } from 'api/common/data';
 import React from 'react';
 import { Button } from 'react-bootstrap';
 
@@ -9,16 +8,6 @@ import { Button } from 'react-bootstrap';
  * @returns Component
  */
 export default function DASRecording(): JSX.Element {
-
-  // start & stop boosting 
-  function startBoosting(){
-    emit('start-boost');
-    
-  }
-
-  function stopBoosting(){
-    emit('stop-boost');
-  }
 
   return (
     <>

--- a/client/src/components/v3/DASRecording.tsx
+++ b/client/src/components/v3/DASRecording.tsx
@@ -11,7 +11,7 @@ export default function DASRecording(): JSX.Element {
 
   return (
     <>
-      <span style={{ fontWeight: 'bold' }}>DAS Recording:</span>
+      <span style={{ fontWeight: 'bold' }}>DAS & BOOST Recording:</span>
       <Button className="ml-3" variant="outline-success" onClick={() => {startLogging(); startBoost();}}>
         Start
       </Button>

--- a/client/src/components/v3/DASRecording.tsx
+++ b/client/src/components/v3/DASRecording.tsx
@@ -1,4 +1,5 @@
 import { startLogging, stopLogging } from 'api/common/data';
+import { emit } from 'api/common/socket';
 import React from 'react';
 import { Button } from 'react-bootstrap';
 
@@ -8,13 +9,24 @@ import { Button } from 'react-bootstrap';
  * @returns Component
  */
 export default function DASRecording(): JSX.Element {
+
+  // start & stop boosting 
+  function startBoosting(){
+    emit('start-boost');
+    
+  }
+
+  function stopBoosting(){
+    emit('stop-boost');
+  }
+
   return (
     <>
       <span style={{ fontWeight: 'bold' }}>DAS Recording:</span>
-      <Button className="ml-3" variant="outline-success" onClick={startLogging}>
+      <Button className="ml-3" variant="outline-success" onClick={() => {startLogging(); startBoosting();}}>
         Start
       </Button>
-      <Button className="ml-2" variant="outline-danger" onClick={stopLogging}>
+      <Button className="ml-2" variant="outline-danger" onClick={() => {stopLogging(); stopBoosting();}}>
         Stop
       </Button>
     </>

--- a/client/src/components/v3/DASRecording.tsx
+++ b/client/src/components/v3/DASRecording.tsx
@@ -1,23 +1,49 @@
 import { startLogging, stopLogging, startBoost, stopBoost } from 'api/common/data';
-import React from 'react';
+import React, {useState} from 'react';
 import { Button } from 'react-bootstrap';
+import toast from 'react-hot-toast';
 
 /**
  * Turn recording off and on
  *
  * @returns Component
  */
-export default function DASRecording(): JSX.Element {
+export default function DASRecording(): JSX.Element { 
+  const [startClicked, setNextStatus] = useState(false);
+
+  function startRecording(){
+    toast.success('DAS & BOOST Recording is started!');
+    setNextStatus(true);
+    startLogging(); 
+    startBoost();
+  }
+
+  function stopRecording () {
+    toast.success('DAS & BOOST Recording is stopped!'); 
+    setNextStatus(false); 
+    stopLogging(); 
+    stopBoost();
+  }
 
   return (
     <>
       <span style={{ fontWeight: 'bold' }}>DAS & BOOST Recording:</span>
-      <Button className="ml-3" variant="outline-success" onClick={() => {startLogging(); startBoost();}}>
+      <Button 
+        className="ml-3" 
+        variant="outline-success" 
+        onClick={startRecording}
+        disabled={startClicked}
+      >
         Start
       </Button>
-      <Button className="ml-2" variant="outline-danger" onClick={() => {stopLogging(); stopBoost();}}>
+      <Button 
+        className="ml-2" 
+        variant="outline-danger" 
+        onClick={stopRecording}
+        disabled={!startClicked}
+      >
         Stop
       </Button>
     </>
-  );
+  ); 
 }

--- a/server/js/sockets.js
+++ b/server/js/sockets.js
@@ -299,11 +299,11 @@ sockets.init = function socketInit(server) {
     });
 
     // TODO: Fix up below socket.io handlers
-    socket.on('start-power-model', () => {
+    socket.on('start-boost', () => {
       mqttClient.publish(BOOST.start, 'true');
     });
 
-    socket.on('stop-power-model', () => {
+    socket.on('stop-boost', () => {
       mqttClient.publish(BOOST.stop, 'true');
     });
 
@@ -374,13 +374,13 @@ sockets.init = function socketInit(server) {
 
     socket.on('start-das-recording', () => {
       [1, 2, 3, 4].forEach((n) =>
-        mqttClient.publish(WirelessModule.id(n).start),
+        mqttClient.publish(WirelessModule.id(n).start, 'true'),
       );
     });
 
     socket.on('stop-das-recording', () => {
       [1, 2, 3, 4].forEach((n) =>
-        mqttClient.publish(WirelessModule.id(n).stop),
+        mqttClient.publish(WirelessModule.id(n).stop, 'true'),
       );
     });
   });

--- a/server/js/sockets.js
+++ b/server/js/sockets.js
@@ -300,11 +300,11 @@ sockets.init = function socketInit(server) {
 
     // TODO: Fix up below socket.io handlers
     socket.on('start-boost', () => {
-      mqttClient.publish(BOOST.start, 'true');
+      mqttClient.publish(BOOST.start);
     });
 
     socket.on('stop-boost', () => {
-      mqttClient.publish(BOOST.stop, 'true');
+      mqttClient.publish(BOOST.stop);
     });
 
     socket.on('reset-calibration', () => {
@@ -374,13 +374,13 @@ sockets.init = function socketInit(server) {
 
     socket.on('start-das-recording', () => {
       [1, 2, 3, 4].forEach((n) =>
-        mqttClient.publish(WirelessModule.id(n).start, 'true'),
+        mqttClient.publish(WirelessModule.id(n).start),
       );
     });
 
     socket.on('stop-das-recording', () => {
       [1, 2, 3, 4].forEach((n) =>
-        mqttClient.publish(WirelessModule.id(n).stop, 'true'),
+        mqttClient.publish(WirelessModule.id(n).stop),
       );
     });
   });


### PR DESCRIPTION
## Description

 the start/stop button on dashboard page now both starts/stops logging and boost 

## Screenshots

## Steps to Test

1. run both client and server 
2.use mosquito broker : mosquitto_sub -t 'boost/start' -h localhost AND mosquitto_sub -t 'boost/stop' -h localhost and must publish the message "true" 
** i also added "true" message for start/stop logging for debugging, checking it works properly or not 
