### PR TITLE
Add scripts to launch client/server from repo root

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,13 @@
 {
   "scripts": {
     "heroku-prebuild": "cd client && yarn install && CI=true yarn build && cd .. && cd server && yarn install",
-    "start": "cd server && yarn start"
+    "client-start": "cd client && yarn start",
+    "server-start": "cd server && yarn start"
   },
-  "cacheDirectories": ["client/node_modules", "server/node_modules"],
+  "cacheDirectories": [
+    "client/node_modules",
+    "server/node_modules"
+  ],
   "engines": {
     "yarn": "1.x",
     "node": "14.x"


### PR DESCRIPTION
## Description

I got sick of having to `cd` into the `client`/`server` directories to launch the dashboard. So, with this change, we can launch them from the root folder :)

## Screenshots

![image](https://user-images.githubusercontent.com/17876556/126157567-b277c27a-3d4d-4ab5-b98a-d5312fe2469f.png)

## Steps to Test

Launch the dashboard with the following:
```bash
yarn run client-start
yarn run server-start
```
and verify that the dashboard is running properly.