### PR TITLE
Fix inconsistency in configs/action topic

### DIFF
--- a/client/src/api/v3/boost.ts
+++ b/client/src/api/v3/boost.ts
@@ -30,7 +30,7 @@ export function sendConfig(
   const payload = {
     action: actionType,
     configType: type,
-    fileName: name,
+    configFileName: name,
     content: configContent,
   };
   // To check things work without needing the server started

--- a/client/src/views/common/BoostView.tsx
+++ b/client/src/views/common/BoostView.tsx
@@ -94,7 +94,7 @@ export default function BoostView() {
 
   const handleDelete = (configType: ConfigT, configName: ConfigNameT) => {
     // Inform `boost`
-    sendConfig('delete', configType, configName.displayName, null);
+    sendConfig('delete', configType, configName.fileName, null);
 
     // Update `dashboard`
     setConfigs(
@@ -117,7 +117,6 @@ export default function BoostView() {
         return config;
       }),
     );
-    toast.success(`${configName.displayName} deleted`);
   };
 
   return (


### PR DESCRIPTION
## Description

There were two issues with DAShboard currently that Eric's new PR in BOOSt helped reveal:
1) DAShboard used `fileName` instead of `configFileName` in one of the MQTT topics
2) DAShboard sent the `displayName` of the file to delete to BOOStT instead of the `fileName` - this became an issue after some recent changes in BOOST but the exam break made me forget to update this repo 😂

## Screenshots

N/A

## Steps to Test

The best way to test this is to run DAShboard and `ericyem/config-saving` in the BOOST repo, and try to delete a config file from the boost page on DAShboard.

Note: Run DAShboard first and then BOOST otherwise the config files sent by BOOST upon start up won't be read by DAShboard
