### PR TITLE
Update V2 Dashboard text mode to accept BOOST JSON data

### DIFF
--- a/client/src/api/common/powerModel.ts
+++ b/client/src/api/common/powerModel.ts
@@ -4,21 +4,21 @@ import { Number, Record, Static } from 'runtypes';
 
 const RecommendedData = Record({
   /** Recommended speed */
-  rec_speed: Number,
+  speed: Number,
   /** Recommended power */
-  rec_power: Number,
+  power: Number,
   /** Distance remaining in current power zone */
-  zdist: Number,
+  zoneDistance: Number,
   /** Distance offset */
-  distance_offset: Number,
+  distanceOffset: Number,
   /** Total distance remaining */
-  distance_left: Number,
+  distanceLeft: Number,
 });
 type RecommendedData = Static<typeof RecommendedData>;
 
 const EstimatedData = Record({
   /** Predicted maximum speed */
-  predicted_max_speed: Number,
+  speed: Number,
 });
 type EstimatedData = Static<typeof EstimatedData>;
 
@@ -34,12 +34,12 @@ export function usePowerModel() {
   const recHandler = useCallback((data: RecommendedData) => {
     setRecData(data);
   }, []);
-  useChannelShaped('power-model-recommended-SP', RecommendedData, recHandler);
+  useChannelShaped('boost/recommended_sp', RecommendedData, recHandler);
 
   const maxHandler = useCallback((data: EstimatedData) => {
     setEstData(data);
   }, []);
-  useChannelShaped('power-model-max-speed', EstimatedData, maxHandler);
+  useChannelShaped('boost/predicted_max_speed', EstimatedData, maxHandler);
 
   return { recData, maxData: estData };
 }

--- a/client/src/components/v2/dashboard/V2TextModeChart.js
+++ b/client/src/components/v2/dashboard/V2TextModeChart.js
@@ -11,7 +11,7 @@ import styles from 'components/v2/dashboard/V2TextModeChart.module.css';
  */
 export default function V2TextModeChart() {
   const data = useData();
-  const { recData, estData } = usePowerModel();
+  const { recData, maxData } = usePowerModel();
 
   /**
    * Format a value into text
@@ -76,27 +76,27 @@ export default function V2TextModeChart() {
             <b>BOOST</b>
           </td>
           <td>Recommended Speed</td>
-          <td>{formatValue(recData?.rec_speed, 'km/h')}</td>
+          <td>{formatValue(recData?.speed, 'km/h')}</td>
         </tr>
         <tr>
           <td>Recommended Power</td>
-          <td>{formatValue(recData?.rec_power, 'W')}</td>
+          <td>{formatValue(recData?.power, 'W')}</td>
         </tr>
         <tr>
           <td>Predicted Max Speed</td>
-          <td>{formatValue(estData?.predictedMaxSpeed, 'km/h')}</td>
+          <td>{formatValue(maxData?.speed, 'km/h')}</td>
         </tr>
         <tr>
           <td>Zone Distance Left</td>
-          <td>{formatValue(recData?.zdist, 'm')}</td>
+          <td>{formatValue(recData?.zoneDistance, 'm')}</td>
         </tr>
         <tr>
           <td>Distance Offset</td>
-          <td>{formatValue(recData?.distance_offset, 'm')}</td>
+          <td>{formatValue(recData?.distanceOffset, 'm')}</td>
         </tr>
         <tr>
           <td>Total Distance Left</td>
-          <td>{formatValue(recData?.distance_left, 'm')}</td>
+          <td>{formatValue(recData?.distanceLeft, 'm')}</td>
         </tr>
         {/* eslint-enable camelcase */}
         <tr>

--- a/server/js/sockets.js
+++ b/server/js/sockets.js
@@ -247,11 +247,11 @@ sockets.init = function socketInit(server) {
 
           case BOOST.predicted_max_speed:
             socket.emit('boost-running');
-            socket.emit('boost/predicted_max_speed', JSON.parse(payloadString));
+            socket.emit(BOOST.predicted_max_speed, JSON.parse(payloadString));
             break;
           case BOOST.recommended_sp:
             socket.emit('boost-running');
-            socket.emit('boost/recommended_sp', JSON.parse(payloadString));
+            socket.emit(BOOST.recommended_sp, JSON.parse(payloadString));
             break;
           case BOOST.configs:
             socket.emit('boost/configs', payloadString);

--- a/server/js/sockets.js
+++ b/server/js/sockets.js
@@ -253,6 +253,10 @@ sockets.init = function socketInit(server) {
             socket.emit('boost-running');
             socket.emit(BOOST.recommended_sp, JSON.parse(payloadString));
             break;
+          case BOOST.achieved_max_speed:
+            socket.emit('boost_running');
+            socket.emit(BOOST.achieved_max_speed, JSON.parse(payloadString));
+            break;
           case BOOST.configs:
             socket.emit('boost/configs', payloadString);
             break;

--- a/server/js/sockets.js
+++ b/server/js/sockets.js
@@ -246,19 +246,12 @@ sockets.init = function socketInit(server) {
             break;
 
           case BOOST.predicted_max_speed:
-            socket.emit('power-model-running');
-            socket.emit(
-              'power-model-max-speed',
-              queryStringToJson(payloadString),
-            );
+            socket.emit('boost-running');
+            socket.emit('boost/predicted_max_speed', JSON.parse(payloadString));
             break;
           case BOOST.recommended_sp:
-            socket.emit('power-model-running');
-            socket.emit(
-              'power-model-recommended-SP',
-              queryStringToJson(payloadString),
-            );
-            socket.emit('boost/recommended_sp', payloadString);
+            socket.emit('boost-running');
+            socket.emit('boost/recommended_sp', JSON.parse(payloadString));
             break;
           case BOOST.configs:
             socket.emit('boost/configs', payloadString);

--- a/server/js/topics.js
+++ b/server/js/topics.js
@@ -12,6 +12,7 @@ class BOOST {
   // BOOST output
   static recommended_sp = 'boost/recommended_sp';
   static predicted_max_speed = 'boost/predicted_max_speed';
+  static achieved_max_speed = 'boost/achieved_max_speed';
   static configs = 'boost/configs';
 
   // Plan generation


### PR DESCRIPTION
## Description

Makes changes as specified in [notion](https://www.notion.so/monashhumanpower/US-3-Update-V2-Dashboard-to-Accept-V3-BOOST-data-1edd6da70e6a4f7daa1bea528d2dc6b8)

- V2 Dashboard expects data from V3 to be in query string format
- PR [https://github.com/monash-human-power/BOOST/pull/63](https://github.com/monash-human-power/BOOST/pull/63) updates BOOST to now use JSON
- We need V2 Dashboard to now work with JSON

## Screenshots

![image](https://user-images.githubusercontent.com/50545432/127193203-d9f23491-fe09-4720-a9e1-a8476ede2d2b.png)

## Steps to Test

1. start dashboard `client` and `server` (`yarn start`)
2. start mqtt (`mosquitto -v`)
3. send payloads
`mosquitto_pub -t boost/predicted_max_speed -m {\"speed\":100}`
`mosquitto_pub -t boost/recommended_sp -m {\"speed\":50,\"power\":300,\"zoneDistance\":50,\"distanceOffset\":10,\"distanceLeft\":200}` 

If there is a mock BOOST thing like we have for DAS please let me know.