### PR TITLE
Miscellaneous changes Part 2

### DIFF
--- a/client/src/components/common/boost/BoostConfigurator.tsx
+++ b/client/src/components/common/boost/BoostConfigurator.tsx
@@ -133,16 +133,18 @@ export default function BoostConfigurator({
   );
 
   const handleGenerate = () => {
-    let allConfigsSelected = true;
+    const configsNotSelected: string[] = [];
     configs.forEach((config) => {
       if (!config.active) {
-        allConfigsSelected = false;
-        toast.error(`Missing selection for ${config.type}`);
+        configsNotSelected.push(config.type);
       }
     });
-    if (allConfigsSelected) {
+    if (configsNotSelected.length === 0) {
       sendConfigSelections(configs);
       setToastId(toast.loading('Generating power plan...'));
+    }
+    else {
+      toast.error(`Missing selection for ${configsNotSelected.join(', ')}`);
     }
   };
 

--- a/client/src/components/common/boost/BoostResults.tsx
+++ b/client/src/components/common/boost/BoostResults.tsx
@@ -15,7 +15,7 @@ export interface BoostResultsProps {
 export default function BoostResults(props: BoostResultsProps) {
   const { results } = props;
   const SPEED_PRECISION = 2;
-  const MS_TO_KMH = 3.6
+  const MS_TO_KMH = 3.6;
 
   const maxSpeed = results ? results.maxSpeed * MS_TO_KMH : null;
 

--- a/client/src/components/common/boost/BoostResults.tsx
+++ b/client/src/components/common/boost/BoostResults.tsx
@@ -14,7 +14,10 @@ export interface BoostResultsProps {
  */
 export default function BoostResults(props: BoostResultsProps) {
   const { results } = props;
-  const speedPrecision = 2;
+  const SPEED_PRECISION = 2;
+  const MS_TO_KMH = 3.6
+
+  const maxSpeed = results ? results.maxSpeed * MS_TO_KMH : null;
 
   return (
     <>
@@ -35,8 +38,8 @@ export default function BoostResults(props: BoostResultsProps) {
                 <b>Max Speed: </b>
                 <span className="float-right">
                   {' '}
-                  {results
-                    ? `${results.maxSpeed.toFixed(speedPrecision)} km/h`
+                  {maxSpeed
+                    ? `${maxSpeed.toFixed(SPEED_PRECISION)} km/h`
                     : 'N/A'}{' '}
                 </span>
               </div>

--- a/client/src/components/v3/dashboard/V3LocationMap.tsx
+++ b/client/src/components/v3/dashboard/V3LocationMap.tsx
@@ -47,7 +47,7 @@ export default function V3LocationMap(): JSX.Element {
 
   // Reset on start
   const reset = () => setLocationHistory([]);
-  useChannel('module-3-start', reset);
+  useChannel('wireless_module-3-start', reset);
 
   // Extract location info from GPS
   const GPS = useSensorData(3, Sensor.GPS, GPSRT);

--- a/client/src/components/v3/dashboard/V3SpeedDistanceChart.tsx
+++ b/client/src/components/v3/dashboard/V3SpeedDistanceChart.tsx
@@ -30,7 +30,7 @@ export function V3SpeedDistanceChart() {
 
   // Reset when start message received
   const reset = () => setData([]);
-  useChannel('module-3-start', reset);
+  useChannel('wireless_module-3-start', reset);
 
   // Speed
   const speed = useSensorData(3, Sensor.GPS, GPSRT)?.speed;

--- a/client/src/views/common/BoostView.tsx
+++ b/client/src/views/common/BoostView.tsx
@@ -70,6 +70,7 @@ export default function BoostView() {
   // Ask server for boost configs when page reloads
   useEffect(() => {
     emit('get-boost-configs', 'boost/configs');
+    emit('get-boost-results', 'boost/generate_complete');
   }, []);
 
   useChannelShaped('boost/configs', ConfigPayloadRT, handleConfigsReceived);

--- a/client/src/views/common/BoostView.tsx
+++ b/client/src/views/common/BoostView.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from 'react';
+import React, { useState, useCallback, useEffect } from 'react';
 import ContentPage from 'components/common/ContentPage';
 import BoostCalibration from 'components/common/boost/BoostCalibration';
 import BoostConfigurator from 'components/common/boost/BoostConfigurator';
@@ -13,7 +13,7 @@ import {
 } from 'types/boost';
 import { useSensorData, Sensor } from 'api/common/data';
 import { Static } from 'runtypes';
-import { useChannelShaped } from 'api/common/socket';
+import { useChannelShaped, emit } from 'api/common/socket';
 import toast from 'react-hot-toast';
 import { ReedDistanceRT } from 'types/data';
 
@@ -66,6 +66,11 @@ export default function BoostView() {
     },
     [],
   );
+
+  // Ask server for boost configs when page reloads
+  useEffect(() => {
+    emit('get-boost-configs', 'boost/configs');
+  }, []);
 
   useChannelShaped('boost/configs', ConfigPayloadRT, handleConfigsReceived);
   useChannelShaped(

--- a/server/js/sockets.js
+++ b/server/js/sockets.js
@@ -23,6 +23,9 @@ const retained = {
   wireless_module: {
     online: null,
   },
+  boost: {
+    configs: null,
+  }
 };
 
 function connectToPublicMQTTBroker(clientID = '') {
@@ -258,6 +261,7 @@ sockets.init = function socketInit(server) {
             socket.emit(BOOST.achieved_max_speed, JSON.parse(payloadString));
             break;
           case BOOST.configs:
+            retained["boost"].configs = payloadString;
             socket.emit('boost/configs', payloadString);
             break;
           case BOOST.generate_complete:
@@ -293,6 +297,11 @@ sockets.init = function socketInit(server) {
     socket.on('get-payload', (path) => {
       if (path instanceof Array && path.length > 0)
         socket.emit(path.join('-'), getPropWithPath(retained, path));
+    });
+
+    socket.on('get-boost-configs', (path) => {
+      if (retained["boost"].configs)
+        socket.emit(path, retained["boost"].configs);
     });
 
     // TODO: Fix up below socket.io handlers

--- a/server/js/sockets.js
+++ b/server/js/sockets.js
@@ -171,6 +171,7 @@ sockets.init = function socketInit(server) {
             retained[path[0]].online = true;
 
             socket.emit(`wireless_module-${id}-online`, true);
+            socket.emit(`wireless_module-${id}-start`, true);
           }
 
           // Module's offline
@@ -251,7 +252,6 @@ sockets.init = function socketInit(server) {
             break;
           case BOOST.configs:
             retained["boost"].configs = payloadString;
-            console.log("recieved");
             socket.emit('boost/configs', payloadString);
             break;
           case BOOST.generate_complete:

--- a/server/js/sockets.js
+++ b/server/js/sockets.js
@@ -102,16 +102,7 @@ sockets.init = function socketInit(server) {
   } else {
     mqttClient = mqtt.connect('mqtt://localhost:1883', mqttOptions);
   }
-  mqttClient.subscribe(DAS.start);
-  mqttClient.subscribe(DAS.stop);
-  mqttClient.subscribe(DAS.data);
-  mqttClient.subscribe(WirelessModule.all().module);
-  mqttClient.subscribe(BOOST.achieved_max_speed);
-  mqttClient.subscribe(BOOST.predicted_max_speed);
-  mqttClient.subscribe(BOOST.generate_complete);
-  mqttClient.subscribe(BOOST.recommended_sp);
-  mqttClient.subscribe(BOOST.configs);
-  mqttClient.subscribe(Camera.push_overlays);
+  
   // Camera recording status subscription occurs when mqttClient message handler is set
   // Camera video feed status subscription occurs when mqttClient message handler is set
   mqttClient.on('connect', mqttConnected);
@@ -260,6 +251,7 @@ sockets.init = function socketInit(server) {
             break;
           case BOOST.configs:
             retained["boost"].configs = payloadString;
+            console.log("recieved");
             socket.emit('boost/configs', payloadString);
             break;
           case BOOST.generate_complete:
@@ -276,6 +268,17 @@ sockets.init = function socketInit(server) {
         }
       }
     });
+
+    mqttClient.subscribe(DAS.start);
+    mqttClient.subscribe(DAS.stop);
+    mqttClient.subscribe(DAS.data);
+    mqttClient.subscribe(WirelessModule.all().module);
+    mqttClient.subscribe(BOOST.achieved_max_speed);
+    mqttClient.subscribe(BOOST.predicted_max_speed);
+    mqttClient.subscribe(BOOST.generate_complete);
+    mqttClient.subscribe(BOOST.recommended_sp);
+    mqttClient.subscribe(BOOST.configs);
+    mqttClient.subscribe(Camera.push_overlays);
 
     // TODO: Remove in refactor, kept here for backwards compatability
     socket.on('get-status-payload', (path) => {


### PR DESCRIPTION
## Description

Bunch of small changes bundled up in this PR:

1) The BOOST config list is now retained within the dashboard ecosystem so that reloads don't make the list disappear 
2) Same thing has been applied to BOOST generated results so they don't get lost when reloading either
3) Error message when you `generate` without any BOOST config selected currently displayed 4 different toast messages. This has been changed to just show one toast with a list of all configs missing.
4) BOOST when publishing to `boost/configs`, retains the message, however since in `socket.js` we subscribe first and then define the `on()` message, the server doesn't handle the retained message on that topic. Hence, we had to always start the server first and then BOOST. This has been fixed now by placing all subscribe code after `on()`'s declaration
5) The Speed vs Distance graph and the Map on the dashboard page were listening to an incorrect (or abandoned) socket channel for the start message on the WM topic. This is fixed, so the graphs and map do not overwrite previous data.

## Screenshots

N/A

## Steps to Test

1) Run BOOST and dashboard (order shouldn't matter)
2) Check each of the 4 points shown above are working
3) for the 5th point you'll need DAShboard and the fake WM script inside `data-aquisition-system/DAS/das/` both running. Only WM 3 is of relevance for now.
