### PR TITLE
DAShboard status page changing both camera video feed and wireless modules online/offline using status

### DIFF
--- a/server/js/sockets.js
+++ b/server/js/sockets.js
@@ -124,8 +124,6 @@ sockets.init = function socketInit(server) {
         Subscribe with the other topics and add a new message handler
         for the topics
     */
-    mqttClient.subscribe('status/#');
-    mqttClient.subscribe('camera/#');
 
     mqttClient.on('message', function mqttMessage(topic, payload) {
       const payloadString = payload.toString();
@@ -165,12 +163,10 @@ sockets.init = function socketInit(server) {
           const [, , id, property] = topicString;
           // topicString: ["v3", "wireless_module", <id>, <property>]
           const value = JSON.parse(payloadString);
-          // const value = JSON.parse('{"online": true}');
           const path = topicString.slice(1); // Path is from "wireless_module"
           // Module's online
           if (property === 'start') {
             retained[path[0]].online = true;
-            // socket.emit(`wireless_module-${id}-online`, true);
             socket.emit(`wireless_module-${id}-start`, true);
           }
           // Module's offline
@@ -278,7 +274,8 @@ sockets.init = function socketInit(server) {
     mqttClient.subscribe(BOOST.recommended_sp);
     mqttClient.subscribe(BOOST.configs);
     mqttClient.subscribe(Camera.push_overlays);
-
+    mqttClient.subscribe(`${Camera.base}/#`);
+    mqttClient.subscribe('status/#');
     // TODO: Remove in refactor, kept here for backwards compatability
     socket.on('get-status-payload', (path) => {
       if (path instanceof Array && path.length > 0)

--- a/server/js/sockets.js
+++ b/server/js/sockets.js
@@ -295,12 +295,12 @@ sockets.init = function socketInit(server) {
 
     socket.on('get-boost-configs', (path) => {
       if (retained.boost.configs)
-        socket.emit(path, retained['boost'].configs);
+        socket.emit(path, retained.boost.configs);
     });
 
     socket.on('get-boost-results', (path) => {
       if (retained.boost.results)
-        socket.emit(path, retained['boost'].results);
+        socket.emit(path, retained.boost.results);
     });
 
     // TODO: Fix up below socket.io handlers

--- a/server/js/sockets.js
+++ b/server/js/sockets.js
@@ -249,11 +249,11 @@ sockets.init = function socketInit(server) {
             socket.emit(BOOST.achieved_max_speed, JSON.parse(payloadString));
             break;
           case BOOST.configs:
-            retained['boost'].configs = payloadString;
+            retained.boost.configs = payloadString;
             socket.emit('boost/configs', payloadString);
             break;
           case BOOST.generate_complete:
-            retained['boost'].results = payloadString;
+            retained.boost.results = payloadString;
             socket.emit('boost/generate_complete', payloadString);
             break;
           case Camera.push_overlays:
@@ -294,12 +294,12 @@ sockets.init = function socketInit(server) {
     });
 
     socket.on('get-boost-configs', (path) => {
-      if (retained['boost'].configs)
+      if (retained.boost.configs)
         socket.emit(path, retained['boost'].configs);
     });
 
     socket.on('get-boost-results', (path) => {
-      if (retained['boost'].results)
+      if (retained.boost.results)
         socket.emit(path, retained['boost'].results);
     });
 

--- a/server/js/sockets.js
+++ b/server/js/sockets.js
@@ -163,22 +163,24 @@ sockets.init = function socketInit(server) {
           const [, , id, property] = topicString;
           // topicString: ["v3", "wireless_module", <id>, <property>]
           const value = JSON.parse(payloadString);
-
+          // const value = JSON.parse('{"online": true}');
+          console.log(value)
+          console.log(property)
           const path = topicString.slice(1); // Path is from "wireless_module"
-
           // Module's online
           if (property === 'start') {
+            console.log(property)
             retained[path[0]].online = true;
 
-            socket.emit(`wireless_module-${id}-online`, true);
+            // socket.emit(`wireless_module-${id}-online`, true);
             socket.emit(`wireless_module-${id}-start`, true);
           }
-
           // Module's offline
-          else if (property === 'stop') {
-            retained[path[0]].online = false;
-
-            socket.emit(`wireless_module-${id}-online`, false);
+          // change to make it look at the status topic of WM 
+          else if (property === 'status') {
+            retained[path[0]].online = value["online"];
+            
+            socket.emit(`wireless_module-${id}-online`, value["online"]);
           }
 
           // Add to global

--- a/server/js/sockets.js
+++ b/server/js/sockets.js
@@ -294,13 +294,11 @@ sockets.init = function socketInit(server) {
     });
 
     socket.on('get-boost-configs', (path) => {
-      if (retained.boost.configs)
-        socket.emit(path, retained.boost.configs);
+      if (retained.boost.configs) socket.emit(path, retained.boost.configs);
     });
 
     socket.on('get-boost-results', (path) => {
-      if (retained.boost.results)
-        socket.emit(path, retained.boost.results);
+      if (retained.boost.results) socket.emit(path, retained.boost.results);
     });
 
     // TODO: Fix up below socket.io handlers

--- a/server/js/sockets.js
+++ b/server/js/sockets.js
@@ -21,7 +21,11 @@ const retained = {
   status: {},
   camera: {},
   wireless_module: {
-    online: null,
+    1: { online: null },
+    2: { online: null },
+    3: { online: null },
+    4: { online: null },
+    // online: null,
   },
   boost: {
     configs: null,
@@ -102,7 +106,6 @@ sockets.init = function socketInit(server) {
   } else {
     mqttClient = mqtt.connect('mqtt://localhost:1883', mqttOptions);
   }
-
   // Camera recording status subscription occurs when mqttClient message handler is set
   // Camera video feed status subscription occurs when mqttClient message handler is set
   mqttClient.on('connect', mqttConnected);
@@ -172,7 +175,7 @@ sockets.init = function socketInit(server) {
           // Module's offline
           // change to make it look at the status topic of WM
           else if (property === 'status') {
-            retained[path[0]].online = value['online'];
+            retained[path[0]][id].online = value['online'];
             socket.emit(`wireless_module-${id}-online`, value['online']);
           }
 
@@ -284,7 +287,7 @@ sockets.init = function socketInit(server) {
           getPropWithPath(retained.status, path),
         );
     });
-
+    // for wireless-module
     socket.on('get-payload', (path) => {
       if (path instanceof Array && path.length > 0)
         socket.emit(path.join('-'), getPropWithPath(retained, path));

--- a/server/js/sockets.js
+++ b/server/js/sockets.js
@@ -26,7 +26,7 @@ const retained = {
   boost: {
     configs: null,
     results: null,
-  }
+  },
 };
 
 function connectToPublicMQTTBroker(clientID = '') {
@@ -102,7 +102,7 @@ sockets.init = function socketInit(server) {
   } else {
     mqttClient = mqtt.connect('mqtt://localhost:1883', mqttOptions);
   }
-  
+
   // Camera recording status subscription occurs when mqttClient message handler is set
   // Camera video feed status subscription occurs when mqttClient message handler is set
   mqttClient.on('connect', mqttConnected);
@@ -114,7 +114,7 @@ sockets.init = function socketInit(server) {
   }
 
   // eslint-disable-next-line global-require
-  const  io = require('socket.io').listen(server);
+  const io = require('socket.io').listen(server);
   io.on('connection', function ioConnection(socket) {
     socket.setMaxListeners(20);
     /*
@@ -144,16 +144,15 @@ sockets.init = function socketInit(server) {
           // Emit subcomponent
           const component = topicString[1] ?? '';
           const subcomponent = topicString[2] ?? '';
-          const device = topicString[3] ?? ''
+          const device = topicString[3] ?? '';
           // if there is a third part to the component
-          const channel = device ? `status-${component}-${subcomponent}-${device}`
-            : `status-${component}-${subcomponent}`
-          const retainedStatus = device ? retained.status?.[component]?.[subcomponent]?.[device] :
-            retained.status?.[component]?.[subcomponent] 
-          socket.emit( 
-            channel,
-            retainedStatus,
-          );
+          const channel = device
+            ? `status-${component}-${subcomponent}-${device}`
+            : `status-${component}-${subcomponent}`;
+          const retainedStatus = device
+            ? retained.status?.[component]?.[subcomponent]?.[device]
+            : retained.status?.[component]?.[subcomponent];
+          socket.emit(channel, retainedStatus);
         } catch (e) {
           console.error(
             `Error in parsing received payload\n\ttopic: ${topic}\n\tpayload: ${payloadString}\n`,
@@ -175,10 +174,10 @@ sockets.init = function socketInit(server) {
             socket.emit(`wireless_module-${id}-start`, true);
           }
           // Module's offline
-          // change to make it look at the status topic of WM 
+          // change to make it look at the status topic of WM
           else if (property === 'status') {
-            retained[path[0]].online = value["online"];
-            socket.emit(`wireless_module-${id}-online`, value["online"]);
+            retained[path[0]].online = value['online'];
+            socket.emit(`wireless_module-${id}-online`, value['online']);
           }
 
           // Add to global
@@ -205,7 +204,7 @@ sockets.init = function socketInit(server) {
           const [, device, property] = topicString;
           const value = JSON.parse(payloadString);
           const path = topicString;
-          
+
           // Add to global
           retained[path[0]] = setPropWithPath(
             retained[path[0]],
@@ -251,11 +250,11 @@ sockets.init = function socketInit(server) {
             socket.emit(BOOST.achieved_max_speed, JSON.parse(payloadString));
             break;
           case BOOST.configs:
-            retained["boost"].configs = payloadString;
+            retained['boost'].configs = payloadString;
             socket.emit('boost/configs', payloadString);
             break;
           case BOOST.generate_complete:
-            retained["boost"].results = payloadString;
+            retained['boost'].results = payloadString;
             socket.emit('boost/generate_complete', payloadString);
             break;
           case Camera.push_overlays:
@@ -295,14 +294,14 @@ sockets.init = function socketInit(server) {
     });
 
     socket.on('get-boost-configs', (path) => {
-      if (retained["boost"].configs)
-        socket.emit(path, retained["boost"].configs);
+      if (retained['boost'].configs)
+        socket.emit(path, retained['boost'].configs);
     });
 
     socket.on('get-boost-results', (path) => {
-      if (retained["boost"].results)
-        socket.emit(path, retained["boost"].results);
-    })
+      if (retained['boost'].results)
+        socket.emit(path, retained['boost'].results);
+    });
 
     // TODO: Fix up below socket.io handlers
     socket.on('start-boost', () => {

--- a/server/js/topics.js
+++ b/server/js/topics.js
@@ -62,6 +62,7 @@ class WirelessModule {
       start: `${module_base}/start`,
       stop: `${module_base}/stop`,
       module: `${module_base}/#`,
+      status: `${module_base}/status`
     };
   }
 


### PR DESCRIPTION
## Description

Changed the the way wireless modules are turned online, should be done by sending the payload through the wireless_module/#/status topic. Fixed the video feed so that it displays "On" or "Off" depending on the camera status feed.
## Screenshots

![image](https://user-images.githubusercontent.com/78238077/133076259-0e4c9646-b536-45e0-bcf5-12122cc6ac45.png)


## Steps to Test

<!--- How does someone check your change? --->
1. Run the DAS server
2. To test the wireless modules going online, send this message: `mosquitto_pub -t "/v3/wireless_module/2/status" -h localhost -m "{\"online\": true}"` and if you want to turn it offline send the same message with false instead of true.
3. To test the camera overlay, take raspicam repo and run: `python orchestrator.py` and `python overlay_new.py --host localhost (need a camera or if background run with --bg (name of background image))`. This should display online in the camera status for the status overview, and the feed should also turn online. Can also test by sending `"status/camera/video_feed/primary" -h localhost -m "{\"online\": true}"` after turning on the camera using `mosquitto_pub -t "status/camera/primary" -h localhost -m "{\"connected\": true}"`
