### PR TITLE
Fix github workflow to clone from mhp common repo

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -10,6 +10,12 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      # This is to allow github actions to clone our private common repository.
+      # The public key is with mhp-deployment github user
+      - uses: webfactory/ssh-agent@v0.5.4
+        with:
+          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+
       - uses: actions/setup-node@v1
         with:
           node-version: '13.x'

--- a/server/service/README.md
+++ b/server/service/README.md
@@ -3,6 +3,9 @@ This folder contains scripts needed to create our own systemd unit service for D
 
 This allows us to start DAShboard `server` when our Raspberry Pi boots up and be able to restart the script if the program crashes.
 
+Note: 
+We do not necessarily need to run dashboard client separately, `server.js` also serves the front-end using the built image from `client/build`. The front-end can then be accessed at port 5000. Hence, we can run dashboard by only running `dashboard_server.service`.
+
 ## Usage
 Run `install.sh` to add `dashboard_server` to the `~/.config/systemd/user/` folder on the OS system.
 


### PR DESCRIPTION
## Description

Ever since we changed to using topics file from our common repository, our GitHub actions workflow has been failing to clone from the repository since its private. This is possibly causing Heroku deployments to fail as well.

The solution is to provide dashboard repository with a private SSH key, with the public one held by our `mhp-deployment` GitHub user. This was manually completed and the workflow yawl is updated to use the Private SSH key from this repo's secrets.

The ssh keys were generated on the secondary-pi, and still remain there under `~/.ssh/github_actions.pub` and `~/.ssh/github_actions` for reference.

We would have to document this process somewhere on notion in the near future.

## Screenshots

N/A

## Steps to Test

Check that the GitHub workflow for this PR is working :)
