### PR TITLE
Derive logging status from incoming MQTT messages

### DIFF
--- a/client/src/api/common/data.ts
+++ b/client/src/api/common/data.ts
@@ -34,11 +34,54 @@ const ModuleData = Record({
   /** Sensor data */
   sensors: Array(SensorDataRT),
 });
+const StartStopData = Record({});
 
 export type ModuleData = Static<typeof ModuleData>;
 
 /**
- * Call a function when WM data is received
+ * Call a function when a WM message is received
+ *
+ * @param id ID of module
+ * @param type The type of message to react to
+ * @param callback The function to be called
+ */
+function useModuleCallback<T>(
+  id: number,
+  type: 'start' | 'stop' | 'data',
+  callback: (payload: T) => void,
+) {
+  const payloadShape: any = type === 'data' ? ModuleData : StartStopData;
+  useChannelShaped(`wireless_module-${id}-${type}`, payloadShape, callback);
+}
+
+/**
+ * Call a function when a WM start message is received
+ *
+ * @param id ID of module
+ * @param callback The function to be called
+ */
+export function useModuleStartCallback(
+  id: number,
+  callback: (data: ModuleData) => void,
+) {
+  useModuleCallback(id, 'start', callback);
+}
+
+/**
+ * Call a function when a WM stop message is received
+ *
+ * @param id ID of module
+ * @param callback The function to be called
+ */
+export function useModuleStopCallback(
+  id: number,
+  callback: (data: ModuleData) => void,
+) {
+  useModuleCallback(id, 'stop', callback);
+}
+
+/**
+ * Call a function when a WM data message is received
  *
  * @param id ID of module
  * @param callback The function to be called
@@ -47,7 +90,7 @@ export function useModuleDataCallback(
   id: number,
   callback: (data: ModuleData) => void,
 ) {
-  useChannelShaped(`wireless_module-${id}-data`, ModuleData, callback);
+  useModuleCallback(id, 'data', callback);
 }
 
 /**

--- a/client/src/api/common/data.ts
+++ b/client/src/api/common/data.ts
@@ -38,6 +38,19 @@ const ModuleData = Record({
 export type ModuleData = Static<typeof ModuleData>;
 
 /**
+ * Call a function when WM data is received
+ *
+ * @param id ID of module
+ * @param callback The function to be called
+ */
+export function useModuleDataCallback(
+  id: number,
+  callback: (data: ModuleData) => void,
+) {
+  useChannelShaped(`wireless_module-${id}-data`, ModuleData, callback);
+}
+
+/**
  * Pass on incoming data from the wireless module channel
  *
  * @param id ID of module
@@ -46,8 +59,7 @@ export type ModuleData = Static<typeof ModuleData>;
 export function useModuleData(id: number): ModuleData {
   const [data, setData] = useState<ModuleData>({ sensors: [] });
 
-  // eslint-disable-next-line no-undef
-  useChannelShaped(`wireless_module-${id}-data`, ModuleData, setData);
+  useModuleDataCallback(id, setData);
 
   return data;
 }
@@ -151,13 +163,13 @@ export function stopLogging() {
 /**
  * Start Boosting
  */
-export function startBoost(){
-  emit('start-boost'); 
+export function startBoost() {
+  emit('start-boost');
 }
 
 /**
  * Stop Boosting
  */
-export function stopBoost(){
+export function stopBoost() {
   emit('stop-boost');
 }

--- a/client/src/components/v3/DASRecording.tsx
+++ b/client/src/components/v3/DASRecording.tsx
@@ -3,6 +3,7 @@ import {
   stopLogging,
   startBoost,
   stopBoost,
+  useModuleDataCallback,
 } from 'api/common/data';
 import React, { useState } from 'react';
 import { Button } from 'react-bootstrap';
@@ -14,20 +15,25 @@ import toast from 'react-hot-toast';
  * @returns Component
  */
 export default function DASRecording(): JSX.Element {
-  const [startClicked, setNextStatus] = useState(false);
+  const [loggingEnabled, setLoggingEnabled] = useState(false);
+
+  useModuleDataCallback(1, () => setLoggingEnabled(true));
+  useModuleDataCallback(2, () => setLoggingEnabled(true));
+  useModuleDataCallback(3, () => setLoggingEnabled(true));
+  useModuleDataCallback(4, () => setLoggingEnabled(true));
 
   /** Start DAS recording and BOOST computations */
   function startRecording() {
-    toast.success('DAS & BOOST Recording is started!');
-    setNextStatus(true);
+    toast.success('DAS & BOOST recording is started!');
+    setLoggingEnabled(true);
     startLogging();
     startBoost();
   }
 
   /** Stop DAS recording and BOOST computations */
   function stopRecording() {
-    toast.success('DAS & BOOST Recording is stopped!');
-    setNextStatus(false);
+    toast.success('DAS & BOOST recording is stopped!');
+    setLoggingEnabled(false);
     stopLogging();
     stopBoost();
   }
@@ -39,7 +45,7 @@ export default function DASRecording(): JSX.Element {
         className="ml-3"
         variant="outline-success"
         onClick={startRecording}
-        disabled={startClicked}
+        disabled={loggingEnabled}
       >
         Start
       </Button>
@@ -47,7 +53,7 @@ export default function DASRecording(): JSX.Element {
         className="ml-2"
         variant="outline-danger"
         onClick={stopRecording}
-        disabled={!startClicked}
+        disabled={!loggingEnabled}
       >
         Stop
       </Button>

--- a/client/src/components/v3/DASRecording.tsx
+++ b/client/src/components/v3/DASRecording.tsx
@@ -4,6 +4,8 @@ import {
   startBoost,
   stopBoost,
   useModuleDataCallback,
+  useModuleStartCallback,
+  useModuleStopCallback,
 } from 'api/common/data';
 import React, { useState } from 'react';
 import { Button } from 'react-bootstrap';
@@ -17,10 +19,20 @@ import toast from 'react-hot-toast';
 export default function DASRecording(): JSX.Element {
   const [loggingEnabled, setLoggingEnabled] = useState(false);
 
+  useModuleStartCallback(1, () => setLoggingEnabled(true));
+  useModuleStartCallback(2, () => setLoggingEnabled(true));
+  useModuleStartCallback(3, () => setLoggingEnabled(true));
+  useModuleStartCallback(4, () => setLoggingEnabled(true));
+
   useModuleDataCallback(1, () => setLoggingEnabled(true));
   useModuleDataCallback(2, () => setLoggingEnabled(true));
   useModuleDataCallback(3, () => setLoggingEnabled(true));
   useModuleDataCallback(4, () => setLoggingEnabled(true));
+
+  useModuleStopCallback(1, () => setLoggingEnabled(false));
+  useModuleStopCallback(2, () => setLoggingEnabled(false));
+  useModuleStopCallback(3, () => setLoggingEnabled(false));
+  useModuleStopCallback(4, () => setLoggingEnabled(false));
 
   /** Start DAS recording and BOOST computations */
   function startRecording() {

--- a/server/js/sockets.js
+++ b/server/js/sockets.js
@@ -170,6 +170,9 @@ sockets.init = function socketInit(server) {
           if (property === 'start') {
             socket.emit(`wireless_module-${id}-start`, true);
           }
+          if (property === 'stop') {
+            socket.emit(`wireless_module-${id}-stop`, true);
+          }
           // Module's offline
           // change to make it look at the status topic of WM
           else if (property === 'status') {


### PR DESCRIPTION
## Description

Right now we assume that logging is always off on dashboard load, which regularly leads to weird situations where the stop button is disabled yet we're clearly receiving data.

With this PR, we update the client's knowledge of what's happening logging-wise from what MQTT messages are received. Start and data messages imply logging is on, stop messages imply logging is off. Until any messages are received, we still assume the off state.

## Screenshots

n/a

## Steps to Test

Run the dashboard, and visit the homepage.
Using `v3_fake_module.py`, verify that the start/stop logging buttons become appropriately enabled/disabled when the script starts and is stopped.
