### PR TITLE
Miscellaneous changes (part 3)

### DIFF
--- a/client/src/api/common/camera.ts
+++ b/client/src/api/common/camera.ts
@@ -234,5 +234,8 @@ export function useCameraBattery(device: Device): CameraBattery | null {
  * @returns Camera status
  */
 export function useCameraStatus(device: Device): CameraStatus | null {
+  useEffect(() => {
+    emit('get-payload', ['status', `camera`, `${device}`]);
+  }, [device]);
   return usePayload(`status-camera-${device}`, CameraStatus);
 }

--- a/client/src/api/common/camera.ts
+++ b/client/src/api/common/camera.ts
@@ -173,6 +173,10 @@ export function formatRecordingPayload(
 export function useCameraRecordingStatus(
   device: Device,
 ): CameraRecordingStatusItem[] | null {
+  useEffect(() => {
+    emit('get-payload', ['status', `camera`, 'recording', `${device}`]);
+  }, [device]);
+
   const payload = usePayload(
     `status-camera-recording-${device}`,
     CameraRecordingStatusPayload,
@@ -192,6 +196,9 @@ export type VideoFeedStatus = Static<typeof VideoFeedStatus>;
  * @returns A VideoFeedStatus for each device
  */
 export function useVideoFeedStatus(device: Device): VideoFeedStatus | null {
+  useEffect(() => {
+    emit('get-payload', ['status', `camera`, 'video_feed', `${device}`]);
+  }, [device]);
   return usePayload(`status-camera-video_feed-${device}`, VideoFeedStatus);
 }
 

--- a/client/src/components/v3/status/WMStatusContainer.tsx
+++ b/client/src/components/v3/status/WMStatusContainer.tsx
@@ -11,7 +11,6 @@ import { useModuleStatus } from 'api/common/data';
  */
 export default function WMStatusContainer() {
   const front = useModuleStatus(1, 'Front WM');
-  const middle = useModuleStatus(2, 'Middle WM');
   const back = useModuleStatus(3, 'Back WM');
   const ant = useModuleStatus(4, 'ANT/DAS WM');
 
@@ -22,9 +21,6 @@ export default function WMStatusContainer() {
         <Row>
           {/* Front WM Status */}
           <WMStatus {...front} />
-
-          {/* Middle WM Status */}
-          <WMStatus {...middle} />
 
           {/* Back WM Status */}
           <WMStatus {...back} />

--- a/server/js/sockets.js
+++ b/server/js/sockets.js
@@ -14,6 +14,9 @@ const { getPropWithPath, setPropWithPath } = require('./util');
 let PUBLISH_ONLINE = false;
 let PUBLIC_MQTT_CLIENT;
 
+// TODO: Add this to the topics.yml file in 'mhp' package
+Camera["base"] = "camera";
+
 /**
  * Structure can be found in the MQTT V3 Topics page on Notion
  */

--- a/server/server.js
+++ b/server/server.js
@@ -43,7 +43,15 @@ server.listen(PORT, () => {
 async function getFiles() {
   const dataFolderPath = path.join(__dirname, 'data');
   const files = await fs.promises.readdir(dataFolderPath);
-  return files;
+
+  return files
+    .map(fileName => ({
+      name: fileName,
+      time: fs.statSync(`${dataFolderPath}/${fileName}`).mtime.getTime(),
+    }))
+    .sort((a, b) => b.time - a.time)
+    .map(file => file.name);
+    
 }
 
 // Endpoint to get a list of files stored on the server

--- a/server/server.js
+++ b/server/server.js
@@ -44,6 +44,7 @@ async function getFiles() {
   const dataFolderPath = path.join(__dirname, 'data');
   const files = await fs.promises.readdir(dataFolderPath);
 
+  // Sorting by last modified date (credit Gaurav Gandhi, https://stackoverflow.com/questions/30727864/how-to-read-a-file-from-directory-sorting-date-modified-in-node-js)
   return files
     .map(fileName => ({
       name: fileName,


### PR DESCRIPTION
## Description

This PR makes the following improvements:
- The camera, video_feed and recording status are all retained (made persistent through browser reloads)
- The log files are now displayed in order of last modified date of the file, with the most recent displayed at the top
- Removed Middle WM since V3 will not include one

## Screenshots

<img width="977" alt="Screen Shot 2022-02-05 at 1 34 40 pm" src="https://user-images.githubusercontent.com/63642262/152636163-c4a0b9cc-b764-47bf-b39b-c1d6288df66f.png">

## Steps to Test

1) Check that middle WM is not shown on the 'Status' Page
2) Create a file in `server/data` and check that the most recently created/modified files appears at the top of the list on the 'Logs' page
3) Publish online status for camera and video feed and confirm they appear on the 'Status' and 'Camera System' pages, respectively:
```
mosquitto_pub -t 'status/camera/primary' -m "{\"connected\":true, \"ipAddress\":\"192.168.0.1\", \"brightness\": 4, \"contrast\": 2}"

mosquitto_pub -t 'status/camera/video_feed/secondary' -m "{\"online\": true}"
```
4) Make sure the status is still correct after page reload
5) Publish recording control status:
```
mosquitto_pub -t 'status/camera/recording/primary' -m "{\"status\":\"off\", \"recordingMinutes\":192.168, \"recordingFile\": \"file.vod\", \"diskSpaceRemaining\": 2, \"error\":\"Out of space\"}"
```
and make sure the details appear on the `Camera Status` page and that they persist beyond page refresh.
