### PR TITLE
Make dashboard get camera voltage from status topic

### DIFF
--- a/client/src/api/common/camera.ts
+++ b/client/src/api/common/camera.ts
@@ -231,7 +231,7 @@ export type CameraBattery = Static<typeof CameraBattery>;
  * @returns Battery
  */
 export function useCameraBattery(device: Device): CameraBattery | null {
-  return usePayload(`camera-${device}-battery`, CameraBattery);
+  return usePayload(`status-camera-${device}-battery`, CameraBattery);
 }
 
 /**


### PR DESCRIPTION
## Description

Dashboard client was expecting the camera voltage to be sent on `camera-primary-battery` channel, but it's actually send on `status-camera-primary-battery`

