### PR TITLE
Fix dashboard Map when GPS signal is not found

### DIFF
--- a/client/src/components/v3/dashboard/V3LocationMap.tsx
+++ b/client/src/components/v3/dashboard/V3LocationMap.tsx
@@ -23,7 +23,8 @@ function isValidLocation(location: LocationTimeSeriesPoint): boolean {
     location.lat <= 90 &&
     Number.isFinite(location.long) &&
     location.long >= -180 &&
-    location.long <= 180
+    location.long <= 180 &&
+    (location.lat != 0 || location.long != 0)
   );
 }
 


### PR DESCRIPTION
## Description

Refactoring Gps code so when latitude and longitude of (0,0) is given the map doesnt display it.

## Screenshots

## Steps to Test

mosquitto_pub -h localhost -t '/v3/wireless_module/3/data' -m "{\"module-id\": 3, \"sensors\": [{\"type\": \"co2\", \"value\": 320.98}, {\"type\": \"reedVelocity\", \"value\": 49.69}, {\"type\": \"reedDistance\", \"value\": 1004.96}, {\"type\": \"gps\", \"value\": {\"speed\": 50.88, \"satellites\": 10.41, \"pdop\": 9.92, \"latitude\": 0, \"longitude\": 0, \"altitude\": 51.23, \"course\": 0.0, \"datetime\": \"2017-11-28 23:55:59.342380\"}}]}"

