### PR TITLE
Temporary fix for Ant plus status logic

### DIFF
--- a/client/src/api/common/data.ts
+++ b/client/src/api/common/data.ts
@@ -164,7 +164,6 @@ export function useModuleStatus(id: number, name: string): WMStatus {
     online: true,
     data,
     batteryVoltage,
-    mqttAddress: '501 Not Implemented',
   };
 }
 

--- a/client/src/components/v3/status/WMStatus.stories.tsx
+++ b/client/src/components/v3/status/WMStatus.stories.tsx
@@ -26,7 +26,6 @@ export const Online = createStory(Template, {
   moduleName: 'Front WM',
   online: true,
   batteryVoltage: 3.123,
-  mqttAddress: '/v3/wireless_module/1/data',
   data: [],
 });
 
@@ -34,7 +33,6 @@ export const Data = createStory(Template, {
   moduleName: 'Front WM',
   online: true,
   batteryVoltage: 3.123,
-  mqttAddress: '/v3/wireless_module/1/data',
   data: [
     sensorData('temperature', 26),
     sensorData('humidity', 62),

--- a/client/src/components/v3/status/WMStatus.tsx
+++ b/client/src/components/v3/status/WMStatus.tsx
@@ -224,12 +224,9 @@ export default function WMStatus(props: WMStatusProps) {
   let info = <> </>;
 
   if (isOnline(props)) {
-    const { data, mqttAddress, batteryVoltage } = props;
+    const { data, batteryVoltage } = props;
     info = (
       <>
-        {/* MQTT address */}
-        <p style={{ fontSize: '0.75rem', color: 'gray' }}>{mqttAddress}</p>
-
         <Table hover>
           <tbody>
             {/* Battery Voltage */}

--- a/client/src/types/data.ts
+++ b/client/src/types/data.ts
@@ -136,7 +136,6 @@ export interface WMStatusOnline {
   online: true;
   data: SensorDataT[];
   batteryVoltage: number;
-  mqttAddress: string;
 }
 
 export interface WMStatusOffline {

--- a/server/js/sockets.js
+++ b/server/js/sockets.js
@@ -193,6 +193,12 @@ sockets.init = function socketInit(server) {
 
             // Emit parsed payload as is
             socket.emit(`wireless_module-${id}-${property}`, value);
+
+            // Temporary fix, if ant+ is sending data, it should be considered online
+            // TODO: Make ant+ send a status message on the status topic instead.
+            if (id === '4') {
+              socket.emit(`wireless_module-${id}-online`, true);
+            }
           }
         } catch (e) {
           console.error(


### PR DESCRIPTION
## Description

Ant plus component does not currently send a status message, hence we need dashboard to infer that it's online when it's sending a message. This PR makes this temporary change. Note that upon refresh the status will again appear offline, which is fine if we keep sending data at a reasonable frequency since it will trigger the status to go online again.

Also as a bonus, I have remove displaying the MQTT Address. I originally thought it would be the IP address of the WM (which is not very meaningful to display), but from the stories file it seems to be the topic name on which the module sends its data. Even in that case, getting the topic name is a bit hard. We can assume the form `/v3/wireless_module/<id>/data` in the front-end, but it just increases coupling between the front and back-end (if we ever change the topic name/format, we would need to manually change it in the front-end as well).

## Screenshots

<img width="1142" alt="Screen Shot 2022-02-13 at 8 50 49 am" src="https://user-images.githubusercontent.com/63642262/153796434-a967502f-6b47-42ce-9db6-01d3b5f16527.png">

## Steps to Test

1) Run dashboard
2) Either get an ant plus dongle and run the ant plus script from data-aquisition-system repo or run the `V3_fake_module.py` script from the same repository.
3) Check that the Power and Heart rate data is being displayed, and if so verify that the Ant plus status appears online on the status page. 