### PR TITLE
Make server calculate max speed + fix flip video feed

### DIFF
--- a/client/src/components/common/camera_settings/OverlaySelection.tsx
+++ b/client/src/components/common/camera_settings/OverlaySelection.tsx
@@ -46,7 +46,7 @@ export default function OverlaySelection({
 
   /** Flipping Video Feed */
   function flipVideo() {
-    emit('flip-video-feed');
+    emit('flip-video-feed', device);
     toast.success('Video feed is flipped!');
   }
 

--- a/client/src/components/v3/StatisticRow.tsx
+++ b/client/src/components/v3/StatisticRow.tsx
@@ -18,12 +18,7 @@ export default function StatisticRow(): JSX.Element {
   // TODO: Multiple sensor data
   const currVel = useSensorData(3, Sensor.ReedVelocity, ReedVelocityRT);
 
-  const temp = (value: number | null) => {
-    console.log(value);
-    setMaxSpeed(value);
-  };
-
-  useChannelShaped('max-speed-achieved', ReedVelocityRT, temp);
+  useChannelShaped('max-speed-achieved', ReedVelocityRT, setMaxSpeed);
 
   // Get max-speed upon page refresh
   useEffect(() => {

--- a/client/src/components/v3/StatisticRow.tsx
+++ b/client/src/components/v3/StatisticRow.tsx
@@ -1,7 +1,7 @@
 import { Sensor, useSensorData } from 'api/common/data';
-import React, { useEffect, useState, useCallback } from 'react';
+import React, { useState, useCallback, useEffect } from 'react';
 import { HeartRateRT, PowerRT, ReedVelocityRT } from 'types/data';
-import { useChannelShaped } from 'api/common/socket';
+import { emit, useChannelShaped } from 'api/common/socket';
 import { SpeedPayload } from 'types/statistic';
 import Statistic from './Statistic';
 import styles from './StatisticRow.module.css';
@@ -18,13 +18,17 @@ export default function StatisticRow(): JSX.Element {
   // TODO: Multiple sensor data
   const currVel = useSensorData(3, Sensor.ReedVelocity, ReedVelocityRT);
 
-  // Update max speed whenever the speed is updated
+  const temp = (value: number | null) => {
+    console.log(value);
+    setMaxSpeed(value);
+  };
+
+  useChannelShaped('max-speed-achieved', ReedVelocityRT, temp);
+
+  // Get max-speed upon page refresh
   useEffect(() => {
-    // Update max speed as the greater of current velocity and previous max
-    if (currVel) setMaxSpeed(Math.max(Math.abs(currVel), maxSpeed ?? 0));
-    // Omit maxSpeed to avoid infinite render loop
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [currVel]);
+    emit('get-max-speed-achieved');
+  }, []);
 
   // Previous Trap Speed (Achieved)
   // eslint-disable-next-line no-unused-vars

--- a/client/src/components/v3/dashboard/V3LocationMap.tsx
+++ b/client/src/components/v3/dashboard/V3LocationMap.tsx
@@ -24,7 +24,7 @@ function isValidLocation(location: LocationTimeSeriesPoint): boolean {
     Number.isFinite(location.long) &&
     location.long >= -180 &&
     location.long <= 180 &&
-    (location.lat != 0 || location.long != 0)
+    (location.lat !== 0 || location.long !== 0)
   );
 }
 

--- a/server/js/sockets.js
+++ b/server/js/sockets.js
@@ -36,7 +36,8 @@ const retained = {
 };
 
 // globals
-max_speed_achieved = -1;
+default_max_speed = -1;
+max_speed_achieved = default_max_speed;
 
 function connectToPublicMQTTBroker(clientID = '') {
   const publicMqttOptions = {
@@ -174,6 +175,9 @@ sockets.init = function socketInit(server) {
           const path = topicString.slice(1); // Path is from "wireless_module"
           // Module's online
           if (property === 'start') {
+            // Reset max_speed_achieved for new round of data
+            max_speed_achieved = default_max_speed;
+
             socket.emit(`wireless_module-${id}-start`, true);
           }
           if (property === 'stop') {

--- a/server/js/sockets.js
+++ b/server/js/sockets.js
@@ -400,9 +400,9 @@ sockets.init = function socketInit(server) {
       mqttClient.publish(Camera.recording_stop);
     });
 
-    socket.on('flip-video-feed', () => {
-      console.log('got to this point too sir no problem');
-      mqttClient.publish(Camera.flip_video_feed);
+    socket.on('flip-video-feed', (device) => {
+      // device is the name of the camera system, i.e. primary/secondary
+      mqttClient.publish(`${Camera.flip_video_feed}/${device}`);
     });
 
     socket.on('start-das-recording', () => {

--- a/server/js/sockets.js
+++ b/server/js/sockets.js
@@ -199,8 +199,9 @@ sockets.init = function socketInit(server) {
 
             // TODO: We should probably get BOOST to store this Max achieved value, so all instances of dashboard can get access to the same consistent value
             if (id === '3') {
-              current_speed = value.sensors.find((s) => s.type === 'reedVelocity')?.value ?? 
-              value.sensors.find((s) => s.type === 'gps')?.value?.speed;
+              current_speed =
+                value.sensors.find((s) => s.type === 'gps')?.value?.speed ??
+                value.sensors.find((s) => s.type === 'reedVelocity')?.value;
 
               if (current_speed && current_speed > max_speed_achieved) {
                 max_speed_achieved = current_speed;

--- a/server/js/sockets.js
+++ b/server/js/sockets.js
@@ -201,9 +201,8 @@ sockets.init = function socketInit(server) {
             if (id === '3') {
               current_speed = value.sensors.find((s) => s.type === 'reedVelocity')?.value ?? 
               value.sensors.find((s) => s.type === 'gps')?.value?.speed;
-              console.log(current_speed);
+
               if (current_speed && current_speed > max_speed_achieved) {
-                console.log('Sending data');
                 max_speed_achieved = current_speed;
                 socket.emit('max-speed-achieved', max_speed_achieved);
               }

--- a/server/js/sockets.js
+++ b/server/js/sockets.js
@@ -15,7 +15,7 @@ let PUBLISH_ONLINE = false;
 let PUBLIC_MQTT_CLIENT;
 
 // TODO: Add this to the topics.yml file in 'mhp' package
-Camera["base"] = "camera";
+Camera['base'] = 'camera';
 
 /**
  * Structure can be found in the MQTT V3 Topics page on Notion
@@ -417,7 +417,8 @@ sockets.init = function socketInit(server) {
       );
     });
     socket.on('get-max-speed-achieved', () => {
-      if (max_speed_achieved >= 0) socket.emit('max-speed-achieved', max_speed_achieved);
+      if (max_speed_achieved >= 0)
+        socket.emit('max-speed-achieved', max_speed_achieved);
     });
   });
 };


### PR DESCRIPTION
## Description

The achieved maximum speed will now be calculated by server, this allows retaining the number upon browser refreshes.
Also updated flip video functionality to send the payload on `camera/flip_video_feed/<primary/secondary>` channel.

## Screenshots

The new channels for flip_video_feed:
<img width="438" alt="Screen Shot 2022-02-21 at 9 09 59 pm" src="https://user-images.githubusercontent.com/63642262/155113322-f9b58592-99ac-4c3d-a23b-dbff023c1c7e.png">

## Steps to Test

1. Run client and server
2. Run the fake module script for data-aquisition-system repo
3. Check that the maximum speed is correctly retained in-between page refreshes
4. Press the flip video button on Camera System page and view that it publishes to the correct channel using:
```
mosquitto_sub -t '#' -v -h localhost
```
