### PR TITLE
fix displaying numbers on dashboard

### DIFF
--- a/client/src/components/common/boost/BoostCalibration.tsx
+++ b/client/src/components/common/boost/BoostCalibration.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useCallback } from 'react';
 import { Button, Card, Form, Col } from 'react-bootstrap';
-import { displayDistance } from 'utils/boost';
+import { roundNum } from 'utils/data';
 
 export interface BoostCalibrationProps {
   onSet: (calibValue: number) => void;
@@ -49,7 +49,7 @@ export default function BoostCalibration({
 
   const displayCalibratedDistance = () => {
     if (calibrationDiff !== null) {
-      return displayDistance(distTravelled + calibrationDiff);
+      return `${roundNum(distTravelled + calibrationDiff, 2)} m`;
     }
     return 'N/A';
   };
@@ -66,7 +66,8 @@ export default function BoostCalibration({
           <b>Distance travelled </b>
           <span className="float-right pr-4">
             {' '}
-            {displayDistance(distTravelled)}{' '}
+            {roundNum(distTravelled, 2)}
+            {' m'}
           </span>
         </div>
         <div className="pb-3">

--- a/client/src/components/v3/Statistic.stories.tsx
+++ b/client/src/components/v3/Statistic.stories.tsx
@@ -18,7 +18,7 @@ export const Null = createStory(Template, {
 });
 
 export const Speed = createStory(Template, {
-  value: 81.4,
+  value: '81.4',
   unit: 'km/h',
   desc: 'Current speed',
 });

--- a/client/src/components/v3/Statistic.tsx
+++ b/client/src/components/v3/Statistic.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 
 export interface StatisticProps {
   /** Value to be shown */
-  value: number | null;
+  value: number | string | null;
   /** Unit of the value */
   unit: string;
   /** Description */
@@ -20,6 +20,7 @@ export default function Statistic({
   unit,
   desc,
 }: StatisticProps): JSX.Element {
+  console.log(value);
   return (
     <>
       <div className={styles.top}>

--- a/client/src/components/v3/Statistic.tsx
+++ b/client/src/components/v3/Statistic.tsx
@@ -20,7 +20,6 @@ export default function Statistic({
   unit,
   desc,
 }: StatisticProps): JSX.Element {
-  console.log(value);
   return (
     <>
       <div className={styles.top}>

--- a/client/src/components/v3/StatisticRow.tsx
+++ b/client/src/components/v3/StatisticRow.tsx
@@ -53,8 +53,6 @@ export default function StatisticRow(): JSX.Element {
 
   const heartRate = useSensorData(4, Sensor.HeartRate, HeartRateRT);
 
-  console.log(roundNum(100.0, 2));
-
   return (
     <div className={styles.statContainer}>
       <div className={styles.statSpeed}>

--- a/client/src/components/v3/StatisticRow.tsx
+++ b/client/src/components/v3/StatisticRow.tsx
@@ -3,6 +3,7 @@ import React, { useEffect, useState, useCallback } from 'react';
 import { HeartRateRT, PowerRT, ReedVelocityRT } from 'types/data';
 import { useChannelShaped } from 'api/common/socket';
 import { SpeedPayload } from 'types/statistic';
+import { roundNum } from 'utils/data';
 import Statistic from './Statistic';
 import styles from './StatisticRow.module.css';
 
@@ -52,18 +53,20 @@ export default function StatisticRow(): JSX.Element {
 
   const heartRate = useSensorData(4, Sensor.HeartRate, HeartRateRT);
 
+  console.log(roundNum(100.0, 2));
+
   return (
     <div className={styles.statContainer}>
       <div className={styles.statSpeed}>
         <Statistic
-          value={currVel ? Math.round(currVel * 100) / 100 : null}
+          value={currVel ? roundNum(currVel, 2) : null}
           unit="km/h"
           desc="Current speed"
         />
       </div>
       <div className={styles.statSpeed}>
         <Statistic
-          value={maxSpeed ? Math.round(maxSpeed * 100) / 100 : null}
+          value={maxSpeed ? roundNum(maxSpeed, 2) : null}
           unit="km/h"
           desc="Max. speed"
         />

--- a/client/src/components/v3/StatisticRow.tsx
+++ b/client/src/components/v3/StatisticRow.tsx
@@ -55,10 +55,18 @@ export default function StatisticRow(): JSX.Element {
   return (
     <div className={styles.statContainer}>
       <div className={styles.statSpeed}>
-        <Statistic value={currVel} unit="km/h" desc="Current speed" />
+        <Statistic
+          value={currVel ? Math.round(currVel * 100) / 100 : null}
+          unit="km/h"
+          desc="Current speed"
+        />
       </div>
       <div className={styles.statSpeed}>
-        <Statistic value={maxSpeed} unit="km/h" desc="Max. speed" />
+        <Statistic
+          value={maxSpeed ? Math.round(maxSpeed * 100) / 100 : null}
+          unit="km/h"
+          desc="Max. speed"
+        />
       </div>
       <div className={styles.statSpeed}>
         <Statistic

--- a/client/src/components/v3/status/WMStatus.tsx
+++ b/client/src/components/v3/status/WMStatus.tsx
@@ -103,7 +103,6 @@ export default function WMStatus(props: WMStatusProps) {
             val *= 3.6;
           }
           displayValue = roundNum(val, dec);
-          console.log(`${name}: ${displayValue}`);
         }
       } else {
         displayValue = '-';

--- a/client/src/components/v3/status/WMStatus.tsx
+++ b/client/src/components/v3/status/WMStatus.tsx
@@ -3,7 +3,7 @@ import { Accordion, Button, Card, Col, Table } from 'react-bootstrap';
 
 import OnlineStatusPill from 'components/common/OnlineStatusPill';
 import { WMStatus as WMStatusT } from 'types/data';
-import { isOnline } from 'utils/data';
+import { isOnline, roundNum } from 'utils/data';
 import { camelCaseToStartCase } from 'utils/string';
 
 export type WMStatusProps = WMStatusT;
@@ -102,7 +102,8 @@ export default function WMStatus(props: WMStatusProps) {
           } else if (unit === 'km/h') {
             val *= 3.6;
           }
-          displayValue = Math.floor(val * 10 ** dec) / 10 ** dec;
+          displayValue = roundNum(val, dec);
+          console.log(`${name}: ${displayValue}`);
         }
       } else {
         displayValue = '-';

--- a/client/src/components/v3/status/WMStatus.tsx
+++ b/client/src/components/v3/status/WMStatus.tsx
@@ -59,7 +59,7 @@ export default function WMStatus(props: WMStatusProps) {
     };
 
     const decimals: numMap2 = {
-      speed: 1,
+      speed: 2,
       satellites: 0,
       pdop: 2,
       latitude: 5,
@@ -73,7 +73,7 @@ export default function WMStatus(props: WMStatusProps) {
       power: 0,
       cadence: 0,
       heartRate: 0,
-      reedVelocity: 1,
+      reedVelocity: 2,
       reedDistance: 2,
       x: 2,
       y: 2,

--- a/client/src/components/v3/status/WMStatus.tsx
+++ b/client/src/components/v3/status/WMStatus.tsx
@@ -74,7 +74,7 @@ export default function WMStatus(props: WMStatusProps) {
       cadence: 0,
       heartRate: 0,
       reedVelocity: 1,
-      reedDistance: 0,
+      reedDistance: 2,
       x: 2,
       y: 2,
       z: 2,

--- a/client/src/utils/boost.ts
+++ b/client/src/utils/boost.ts
@@ -12,7 +12,3 @@ export const removeSuffix = (name: string, type: ConfigT) =>
 
 export const addSuffix = (name: string, type: ConfigT) =>
   name.replace('.json', configTypeToFileSuffix[type]);
-
-export const displayDistance = (num: number) => {
-  return `${Number.parseFloat(num.toString()).toFixed(2)} m`;
-};

--- a/client/src/utils/data.ts
+++ b/client/src/utils/data.ts
@@ -9,3 +9,6 @@ import { WMStatus, WMStatusOnline } from 'types/data';
 export function isOnline(props: WMStatus): props is WMStatusOnline {
   return !!props.online;
 }
+export const roundNum = (num: number, precision: number) => {
+  return `${Number.parseFloat(num.toString()).toFixed(precision)}`;
+};


### PR DESCRIPTION
### Description
This PR fixes the display of various numbers (reed distance, current and max speed) to use 2 decimal places.

### Test
1) Run dashboard
2) Use the following 3 commands to test various inputs and confirm the rounding and display is correct:

- Confirm the current and max speed on main page shows `360.00`:
```
mosquitto_pub -h localhost -t '/v3/wireless_module/3/data' -m '{"module-id": 3, "sensors": [{"type": "co2", "value": 320.98}, {"type": "reedVelocity", "value": 360.000}, {"type": "reedDistance", "value": 5000.000}, {"type": "gps", "value": {"speed": 50.88, "satellites": 10.41, "pdop": 9.92, "latitude": 0.23, "longitude": 120.1234567, "altitude": 51.23, "course": 50.0123, "datetime": "2017-11-28 23:55:59.342380"}}]}'
```
<img width="412" alt="Screen Shot 2022-03-17 at 5 44 33 pm" src="https://user-images.githubusercontent.com/63642262/158752675-fbad05c2-6f1f-41f3-9f16-ec36f50ecdc5.png">

------
- Go to status page, publish WM3 as online:
```
mosquitto_pub -t '/v3/wireless_module/3/status' -m '{"online": true}'
```
Then publish the following and confirm reed distance and velocity shows correct decimal places:
```
mosquitto_pub -h localhost -t '/v3/wireless_module/3/data' -m '{"module-id": 3, "sensors": [{"type": "co2", "value": 320.98}, {"type": "reedVelocity", "value": 360.000}, {"type": "reedDistance", "value": 128.735}, {"type": "gps", "value": {"speed": 50.88, "satellites": 10.41, "pdop": 9.92, "latitude": 0.23, "longitude": 120.1234567, "altitude": 51.23, "course": 50.0123, "datetime": "2017-11-28 23:55:59.342380"}}]}'
```

<img width="415" alt="Screen Shot 2022-03-17 at 5 48 26 pm" src="https://user-images.githubusercontent.com/63642262/158752847-de9dc601-c622-4207-939d-9c90c2fc0972.png">

------
- Since this PR refactors a bit of boost, check that the following data packet displays the correct distance on boost page of `123.00`:
```
mosquitto_pub -h localhost -t '/v3/wireless_module/3/data' -m '{"module-id": 3, "sensors": [{"type": "co2", "value": 320.98}, {"type": "reedVelocity", "value": 360.000}, {"type": "reedDistance", "value": 123.004}, {"type": "gps", "value": {"speed": 50.88, "satellites": 10.41, "pdop": 9.92, "latitude": 0.23, "longitude": 120.1234567, "altitude": 51.23, "course": 50.0123, "datetime": "2017-11-28 23:55:59.342380"}}]}'
```

<img width="973" alt="Screen Shot 2022-03-17 at 5 46 01 pm" src="https://user-images.githubusercontent.com/63642262/158752883-b47f4e4d-30fd-44d4-b832-7ac0f1df91a8.png">


