### PR TITLE
Get max speed achieved from BOOST topic

### DIFF
--- a/client/src/components/common/camera_settings/OverlaySelection.tsx
+++ b/client/src/components/common/camera_settings/OverlaySelection.tsx
@@ -46,7 +46,7 @@ export default function OverlaySelection({
 
   /** Flipping Video Feed */
   function flipVideo() {
-    emit('flip-video-feed');
+    emit('flip-video-feed', device);
     toast.success('Video feed is flipped!');
   }
 

--- a/client/src/components/v3/StatisticRow.tsx
+++ b/client/src/components/v3/StatisticRow.tsx
@@ -1,7 +1,7 @@
 import { Sensor, useSensorData } from 'api/common/data';
 import React, { useEffect, useState, useCallback } from 'react';
-import { HeartRateRT, PowerRT, ReedVelocityRT } from 'types/data';
-import { useChannelShaped } from 'api/common/socket';
+import { MaxSpeedRT, HeartRateRT, PowerRT, ReedVelocityRT } from 'types/data';
+import { useChannelShaped, emit } from 'api/common/socket';
 import { SpeedPayload } from 'types/statistic';
 import Statistic from './Statistic';
 import styles from './StatisticRow.module.css';
@@ -18,13 +18,11 @@ export default function StatisticRow(): JSX.Element {
   // TODO: Multiple sensor data
   const currVel = useSensorData(3, Sensor.ReedVelocity, ReedVelocityRT);
 
-  // Update max speed whenever the speed is updated
+  useChannelShaped('boost/max_speed_achieved', MaxSpeedRT, setMaxSpeed);
+  // Get max speed whenever page refreshes
   useEffect(() => {
-    // Update max speed as the greater of current velocity and previous max
-    if (currVel) setMaxSpeed(Math.max(Math.abs(currVel), maxSpeed ?? 0));
-    // Omit maxSpeed to avoid infinite render loop
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [currVel]);
+    emit('get-max-speed-achieved', 'boost/max_speed_achieved');
+  }, []);
 
   // Previous Trap Speed (Achieved)
   // eslint-disable-next-line no-unused-vars

--- a/client/src/types/data.ts
+++ b/client/src/types/data.ts
@@ -1,6 +1,9 @@
-import { Number, Record, Static, String, Union } from 'runtypes';
+import { Number, Record, Static, String, Union, Null } from 'runtypes';
 
 /* ------------------------------------ RunTypes ------------------------------------ */
+
+/** Value runtype of temperature sensor data */
+export const MaxSpeedRT = Union(Number, Null);
 
 /** Value runtype of temperature sensor data */
 export const TemperatureRT = Number;

--- a/server/js/sockets.js
+++ b/server/js/sockets.js
@@ -33,6 +33,7 @@ const retained = {
     configs: null,
     results: null,
   },
+  max_speed_achieved: null,
 };
 
 function connectToPublicMQTTBroker(clientID = '') {
@@ -173,7 +174,7 @@ sockets.init = function socketInit(server) {
           if (property === 'start') {
             socket.emit(`wireless_module-${id}-start`, true);
           }
-          if (property === 'stop') {
+          else if (property === 'stop') {
             socket.emit(`wireless_module-${id}-stop`, true);
           }
           // Module's offline
@@ -194,11 +195,6 @@ sockets.init = function socketInit(server) {
             // Emit parsed payload as is
             socket.emit(`wireless_module-${id}-${property}`, value);
 
-            // Temporary fix, if ant+ is sending data, it should be considered online
-            // TODO: Make ant+ send a status message on the status topic instead.
-            if (id === '4') {
-              socket.emit(`wireless_module-${id}-online`, true);
-            }
           }
         } catch (e) {
           console.error(
@@ -247,8 +243,15 @@ sockets.init = function socketInit(server) {
             }
             break;
           case BOOST.predicted_max_speed:
+            // FIXME: Not sure why we send this currently?
             socket.emit('boost-running');
             socket.emit(BOOST.predicted_max_speed, JSON.parse(payloadString));
+            break;
+          case BOOST.max_speed_achieved:
+            console.log(payloadString);
+            const max_speed = payloadString ? JSON.parse(payloadString)["speed"] : null;
+            retained.max_speed_achieved = max_speed;
+            socket.emit(BOOST.max_speed_achieved, max_speed);
             break;
           case BOOST.recommended_sp:
             socket.emit('boost-running');
@@ -283,6 +286,7 @@ sockets.init = function socketInit(server) {
     mqttClient.subscribe(WirelessModule.all().module);
     mqttClient.subscribe(BOOST.prev_trap_speed);
     mqttClient.subscribe(BOOST.predicted_max_speed);
+    mqttClient.subscribe(BOOST.max_speed_achieved);
     mqttClient.subscribe(BOOST.generate_complete);
     mqttClient.subscribe(BOOST.recommended_sp);
     mqttClient.subscribe(BOOST.configs);
@@ -302,6 +306,9 @@ sockets.init = function socketInit(server) {
       if (path instanceof Array && path.length > 0)
         socket.emit(path.join('-'), getPropWithPath(retained, path));
     });
+    socket.on('get-max-speed-achieved', (path) => {
+      if (retained.max_speed_achieved) socket.emit(path, retained.max_speed_achieved);
+    })
 
     socket.on('get-boost-configs', (path) => {
       if (retained.boost.configs) socket.emit(path, retained.boost.configs);

--- a/server/js/sockets.js
+++ b/server/js/sockets.js
@@ -392,9 +392,9 @@ sockets.init = function socketInit(server) {
       mqttClient.publish(Camera.recording_stop);
     });
 
-    socket.on('flip-video-feed', () => {
-      console.log('got to this point too sir no problem');
-      mqttClient.publish(Camera.flip_video_feed);
+    socket.on('flip-video-feed', (device) => {
+      // device is the name of the camera system, i.e. primary/secondary
+      mqttClient.publish(`${Camera.flip_video_feed}/${device}`);
     });
 
     socket.on('start-das-recording', () => {


### PR DESCRIPTION
## Description

1) Currently the client calculates the maximum speed achieved. However, this means each version of dashboard would display a different maximum speed achieved and upon browser refresh it will reset. To avoid this, BOOSt now calculates, stores and sends the maximum speed achieved. This PR makes the server listen to this speed and provide it to the front-end whenever a new value has been read or the browser has been refreshed.

2) The camera flip video feed functionality has been updated so that we now publish to the `camera/flip_video_feed/>primary/secondary` topic instead to distinct between whether we're flipping the primary or secondary camera feed.

## Screenshots
Clicking the flip video button and the resultant topic that the message is sent to:
<img width="198" alt="Screen Shot 2022-03-27 at 6 00 07 pm" src="https://user-images.githubusercontent.com/63642262/160270806-3083a6bf-5f28-482c-a869-7fe6bdf1696c.png">
<img width="306" alt="Screen Shot 2022-03-27 at 6 00 23 pm" src="https://user-images.githubusercontent.com/63642262/160270808-672d6ee0-331a-4af2-a221-3b21857f86a1.png">

Note how the max speed displayed at the top is different to the max speed highlighted on the graph, because the max speed at the top is universally consistent across every dashboard instance now. I had opened this tab after a few rounds of fake data were published...
<img width="566" alt="Screen Shot 2022-03-27 at 6 03 59 pm" src="https://user-images.githubusercontent.com/63642262/160270813-e2b41e60-c7ab-4cd4-af8f-5ea81fea569b.png">

## Steps to Test

1) Run dashboard and in a seperate terminal subscribe to 
```
mosquitto_sub -t '#' -v
```
2) Click the flip video buttons on the Camera page, and check the relevant topic is being used to send the message in the terminal
3) To test the maximum speed achieved changes, run the fake module script from `data-aquisition-system` repository and run BOOST repository (from branch `eric/max-speed-2`).
4) After a few maximum speed data points are sent, try refreshing to ensure the max speed is retained and then open dashboard in another tab or browser and confirm the max speed displayed is same on both instances.
