### PR TITLE
Use ant+ speed/distance on dashboard

### DIFF
--- a/client/src/api/common/data.ts
+++ b/client/src/api/common/data.ts
@@ -24,6 +24,8 @@ export enum Sensor {
   Gyroscope = 'gyroscope',
   ReedVelocity = 'reedVelocity',
   ReedDistance = 'reedDistance',
+  AntSpeed = 'antSpeed',
+  AntDistance = 'antDistance',
   GPS = 'gps',
   Power = 'power',
   Cadence = 'cadence',

--- a/client/src/components/v3/StatisticRow.tsx
+++ b/client/src/components/v3/StatisticRow.tsx
@@ -55,14 +55,14 @@ export default function StatisticRow(): JSX.Element {
     <div className={styles.statContainer}>
       <div className={styles.statSpeed}>
         <Statistic
-          value={currVel ? roundNum(currVel, 2) : null}
+          value={currVel ? roundNum(currVel * 3.6, 2) : null}
           unit="km/h"
           desc="Current speed"
         />
       </div>
       <div className={styles.statSpeed}>
         <Statistic
-          value={maxSpeed ? roundNum(maxSpeed, 2) : null}
+          value={maxSpeed ? roundNum(maxSpeed * 3.6, 2) : null}
           unit="km/h"
           desc="Max. speed"
         />

--- a/client/src/components/v3/StatisticRow.tsx
+++ b/client/src/components/v3/StatisticRow.tsx
@@ -1,6 +1,6 @@
 import { Sensor, useSensorData } from 'api/common/data';
 import React, { useEffect, useState, useCallback } from 'react';
-import { MaxSpeedRT, HeartRateRT, PowerRT, ReedVelocityRT } from 'types/data';
+import { MaxSpeedRT, HeartRateRT, PowerRT, AntSpeedRT } from 'types/data';
 import { useChannelShaped, emit } from 'api/common/socket';
 import { SpeedPayload } from 'types/statistic';
 import { roundNum } from 'utils/data';
@@ -17,7 +17,7 @@ export default function StatisticRow(): JSX.Element {
   const [maxSpeed, setMaxSpeed] = useState<number | null>(null);
 
   // TODO: Multiple sensor data
-  const currVel = useSensorData(3, Sensor.ReedVelocity, ReedVelocityRT);
+  const currVel = useSensorData(4, Sensor.AntSpeed, AntSpeedRT);
 
   useChannelShaped('boost/max_speed_achieved', MaxSpeedRT, setMaxSpeed);
   // Get max speed whenever page refreshes

--- a/client/src/components/v3/dashboard/V3SpeedDistanceChart.tsx
+++ b/client/src/components/v3/dashboard/V3SpeedDistanceChart.tsx
@@ -4,7 +4,7 @@ import { Sensor, useSensorData } from 'api/common/data';
 import { useChannel } from 'api/common/socket';
 import SpeedDistanceChart from 'components/common/charts/SpeedDistanceChart';
 import { ChartPoint } from 'types/chart';
-import { GPSRT, ReedDistanceRT } from 'types/data';
+import { AntDistanceRT, AntSpeedRT } from 'types/data';
 
 export const V3SDChartKey = 'v3-dashboard-speed-distance-chart-data';
 
@@ -30,11 +30,11 @@ export function V3SpeedDistanceChart() {
 
   // Reset when start message received
   const reset = () => setData([]);
-  useChannel('wireless_module-3-start', reset);
+  useChannel('wireless_module-4-start', reset);
 
   // Speed
-  const speed = useSensorData(3, Sensor.GPS, GPSRT)?.speed;
-  const distance = useSensorData(3, Sensor.ReedDistance, ReedDistanceRT);
+  const speed = useSensorData(4, Sensor.AntSpeed, AntSpeedRT);
+  const distance = useSensorData(4, Sensor.AntDistance, AntDistanceRT);
 
   // Update data whenever the point is updated
   useEffect(() => {

--- a/client/src/components/v3/dashboard/V3SpeedDistanceChart.tsx
+++ b/client/src/components/v3/dashboard/V3SpeedDistanceChart.tsx
@@ -45,8 +45,9 @@ export function V3SpeedDistanceChart() {
       // New distance measurement
       distance !== data[data.length - 1]?.x
     ) {
-      maxSpeed.current = Math.max(maxSpeed.current, speed);
-      setData([...data, { x: distance, y: speed }]);
+      const speedKmh = speed * 3.6;
+      maxSpeed.current = Math.max(maxSpeed.current, speedKmh);
+      setData([...data, { x: distance, y: speedKmh }]);
     }
     // Omit data in deps as otherwise there would be an infinite render loop
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/client/src/components/v3/status/WMStatus.tsx
+++ b/client/src/components/v3/status/WMStatus.tsx
@@ -56,6 +56,8 @@ export default function WMStatus(props: WMStatusProps) {
       heartRate: 'bpm',
       reedVelocity: 'km/h',
       reedDistance: 'km',
+      antSpeed: 'km/h',
+      antDistance: 'km',
     };
 
     const decimals: numMap2 = {
@@ -75,6 +77,8 @@ export default function WMStatus(props: WMStatusProps) {
       heartRate: 0,
       reedVelocity: 2,
       reedDistance: 2,
+      antSpeed: 2,
+      antDistance: 2,
       x: 2,
       y: 2,
       z: 2,

--- a/client/src/types/data.ts
+++ b/client/src/types/data.ts
@@ -86,6 +86,8 @@ export const SensorsRT = Union(
   GyroscopeRT,
   ReedVelocityRT,
   ReedDistanceRT,
+  AntSpeedRT,
+  AntDistanceRT,
   GPSRT,
   PowerRT,
   CadenceRT,
@@ -123,6 +125,12 @@ export type ReedVelocityT = Static<typeof ReedVelocityRT>;
 
 /** Value type of reedDistance sensor data */
 export type ReedDistanceT = Static<typeof ReedDistanceRT>;
+
+/** Value type of antSpeed sensor data */
+export type AntSpeedT = Static<typeof AntSpeedRT>;
+
+/** Value type of antDistance sensor data */
+export type AntDistanceT = Static<typeof AntDistanceRT>;
 
 /** Value type of gps sensor data */
 export type GPST = Static<typeof GPSRT>;

--- a/client/src/types/data.ts
+++ b/client/src/types/data.ts
@@ -43,6 +43,12 @@ export const ReedVelocityRT = Number;
 /** Value runtype of reedDistance sensor data */
 export const ReedDistanceRT = Number;
 
+/** Value runtype of antSpeed sensor data */
+export const AntSpeedRT = Number;
+
+/** Value runtype of antDistance sensor data */
+export const AntDistanceRT = Number;
+
 /** Value runtype of gps sensor data */
 export const GPSRT = Record({
   /** Speed */

--- a/client/src/views/common/BoostView.tsx
+++ b/client/src/views/common/BoostView.tsx
@@ -15,7 +15,7 @@ import { useSensorData, Sensor } from 'api/common/data';
 import { Static } from 'runtypes';
 import { useChannelShaped, emit } from 'api/common/socket';
 import toast from 'react-hot-toast';
-import { ReedDistanceRT } from 'types/data';
+import { AntDistanceRT } from 'types/data';
 
 /**
  * Boost View component
@@ -44,9 +44,8 @@ export default function BoostView() {
     },
   ]);
 
-  // fetch the reed distance from wireless module #3
-  const reedDistance =
-    useSensorData(3, Sensor.ReedDistance, ReedDistanceRT) ?? 0;
+  // fetch the ant+ distance from wireless module #4
+  const antDistance = useSensorData(4, Sensor.AntDistance, AntDistanceRT) ?? 0;
 
   const handleConfigsReceived = useCallback(
     (configsReceived: Static<typeof ConfigPayloadRT>) => {
@@ -130,7 +129,7 @@ export default function BoostView() {
       <BoostCalibration
         onSet={setCalibration}
         onReset={handleReset}
-        distTravelled={reedDistance}
+        distTravelled={antDistance}
         calibrationDiff={distOffset}
       />
       <BoostConfigurator

--- a/server/js/sockets.js
+++ b/server/js/sockets.js
@@ -248,7 +248,6 @@ sockets.init = function socketInit(server) {
             socket.emit(BOOST.predicted_max_speed, JSON.parse(payloadString));
             break;
           case BOOST.max_speed_achieved:
-            console.log(payloadString);
             const max_speed = payloadString ? JSON.parse(payloadString)["speed"] : null;
             retained.max_speed_achieved = max_speed;
             socket.emit(BOOST.max_speed_achieved, max_speed);


### PR DESCRIPTION
## Description

Title. Updates the statistic field, speed graph, status page and boost page.

## Screenshots

It ain't perfect but it's not bad for 3 AM

![image](https://user-images.githubusercontent.com/17876556/162257965-bc16b75d-4eba-4592-8473-f7a17d6f54a0.png)

## Steps to Test

Run the dashboard. Then send some test data:

```
mosquitto_pub -t "/v3/wireless_module/4/data" -m "{"sensors":[{"type":"antSpeed","value":2.305735965665236},{"type":"antDistance","value":251.82960000000003}]}"
```
