### PR TITLE
Implement V3 Start Topic for Dashboard

### DIFF
--- a/client/src/api/common/data.ts
+++ b/client/src/api/common/data.ts
@@ -220,3 +220,17 @@ export function startBoost() {
 export function stopBoost() {
   emit('stop-boost');
 }
+
+/***
+ * Start V3
+ */
+export function startV3() {
+  emit('start-V3');
+}
+
+/***
+ * Stop V3
+ */
+export function stopV3() {
+  emit('stop-V3');
+}

--- a/client/src/api/common/data.ts
+++ b/client/src/api/common/data.ts
@@ -193,34 +193,6 @@ export function useSensorData<T extends SensorsT>(
   return Union(shape, Null).check(data);
 }
 
-/**
- * Starts DAS log recording
- */
-export function startLogging() {
-  emit('start-das-recording');
-}
-
-/**
- * Stops DAS log recording
- */
-export function stopLogging() {
-  emit('stop-das-recording');
-}
-
-/**
- * Start Boosting
- */
-export function startBoost() {
-  emit('start-boost');
-}
-
-/**
- * Stop Boosting
- */
-export function stopBoost() {
-  emit('stop-boost');
-}
-
 /***
  * Start V3
  */

--- a/client/src/components/v3/DASRecording.tsx
+++ b/client/src/components/v3/DASRecording.tsx
@@ -3,6 +3,8 @@ import {
   stopLogging,
   startBoost,
   stopBoost,
+  startV3,
+  stopV3,
   useModuleDataCallback,
   useModuleStartCallback,
   useModuleStopCallback,
@@ -42,6 +44,7 @@ export default function DASRecording(): JSX.Element {
     setLoggingEnabled(true);
     startLogging();
     startBoost();
+    startV3();
   }
 
   /** Stop DAS recording and BOOST computations */
@@ -50,6 +53,7 @@ export default function DASRecording(): JSX.Element {
     setLoggingEnabled(false);
     stopLogging();
     stopBoost();
+    stopV3();
   }
 
   return (

--- a/client/src/components/v3/DASRecording.tsx
+++ b/client/src/components/v3/DASRecording.tsx
@@ -1,8 +1,4 @@
 import {
-  startLogging,
-  stopLogging,
-  startBoost,
-  stopBoost,
   startV3,
   stopV3,
   useModuleDataCallback,
@@ -42,8 +38,6 @@ export default function DASRecording(): JSX.Element {
   function startRecording() {
     toast.success('DAS & BOOST recording is started!');
     setLoggingEnabled(true);
-    startLogging();
-    startBoost();
     startV3();
   }
 
@@ -51,8 +45,6 @@ export default function DASRecording(): JSX.Element {
   function stopRecording() {
     toast.success('DAS & BOOST recording is stopped!');
     setLoggingEnabled(false);
-    stopLogging();
-    stopBoost();
     stopV3();
   }
 

--- a/server/js/sockets.js
+++ b/server/js/sockets.js
@@ -7,7 +7,7 @@ const sockets = {};
 const mqtt = require('mqtt');
 const os = require('os');
 
-const { DAS, BOOST, Camera, WirelessModule } = require('mhp');
+const { DAS, BOOST, Camera, WirelessModule, V3 } = require('mhp');
 const { getPropWithPath, setPropWithPath } = require('./util');
 
 // Public MQTT broker
@@ -234,6 +234,19 @@ sockets.init = function socketInit(server) {
           case DAS.stop:
             socket.emit('stop');
             break;
+          case V3.start:
+            const msg = JSON.parse(payload);
+            if (msg.start){
+                [1, 2, 3, 4].forEach((n) =>
+                socket.emit(`wireless_module-${id}-start`, true),
+              );
+              }
+            else{
+              [1, 2, 3, 4].forEach((n) =>
+                socket.emit(`wireless_module-${id}-stop`, true),
+              );
+            }
+            break;
 
           // V2 data channel
           case DAS.data:
@@ -282,6 +295,7 @@ sockets.init = function socketInit(server) {
     // Subscribe to topics after defining the 'on' method to ensure we catch any message sent immediately upon subscribing (e.g. retained messages)
     mqttClient.subscribe(DAS.start);
     mqttClient.subscribe(DAS.stop);
+    mqttClient.subscribe(V3.start);
     mqttClient.subscribe(DAS.data);
     mqttClient.subscribe(WirelessModule.all().module);
     mqttClient.subscribe(BOOST.prev_trap_speed);
@@ -408,6 +422,15 @@ sockets.init = function socketInit(server) {
         mqttClient.publish(WirelessModule.id(n).stop),
       );
     });
+    
+    socket.on('start-V3', ()=>{
+      mqttClient.publish(V3.start, JSON.stringify({"start": true}));      
+    })
+
+    socket.on('stop-V3', ()=>{
+      mqttClient.publish(V3.start, JSON.stringify({"start": false}));
+    })
+
   });
 };
 

--- a/server/js/sockets.js
+++ b/server/js/sockets.js
@@ -237,12 +237,12 @@ sockets.init = function socketInit(server) {
           case V3.start:
             const msg = JSON.parse(payload);
             if (msg.start){
-                [1, 2, 3, 4].forEach((n) =>
+                [1, 2, 3, 4].forEach((id) =>
                 socket.emit(`wireless_module-${id}-start`, true),
               );
               }
             else{
-              [1, 2, 3, 4].forEach((n) =>
+              [1, 2, 3, 4].forEach((id) =>
                 socket.emit(`wireless_module-${id}-stop`, true),
               );
             }


### PR DESCRIPTION
## Description
Changes were made to both the client and the server, to allow for the new V3 start topic to be implemented. This involves sending a start message when the 'Start Logging' button is pressed on the dashboard, and also sending a stop message when the 'Stop Logging' button is pressed. 

## Screenshots

**Dual Terminals**
![image](https://user-images.githubusercontent.com/97724307/188785434-ca2e72b3-4a8f-485d-84df-985daeefe17f.png)

**Dasboard**
![image](https://user-images.githubusercontent.com/97724307/188785804-cb39571e-6291-4301-b198-66f5825b65f8.png)

**MQTT Start**
![image](https://user-images.githubusercontent.com/97724307/188786665-8996de3d-e1c0-486c-9900-554bebe65f57.png)


## Steps to Test

1. Before beginning testing ensure steps from ReadMe have been followed and that your MQTT broker is running.  
2. Open dual command prompts or Powershells, as seen in _Dual Terminals_.
3. In one terminal switch to the `client` folder and in the other switch to the `server` folder, as seen in _Dual Terminals_.
4. In the `server` directory run `yarn start`.
5. In the `client`  directory run `yarn start`.
6. The Dashboard website should now be open on your browser, as seen in _Dashboard_.
7. Open a new terminal and run `mosquitto_sub -t 'v3/start'`.
8. Press the **start** button, and then the **stop** button, your terminal should look like _MQTT Start_.
   - Pressing the **start** button will send a true message, concurrently pressing **stop** will send a false message.
 

<!--- How does someone check your change? --->
