### PR TITLE
Added keys to lists

### DIFF
--- a/client/src/components/common/navbar/NavBar.stories.tsx
+++ b/client/src/components/common/navbar/NavBar.stories.tsx
@@ -26,6 +26,7 @@ export const V2 = createStory(Template, {
     name: 'Version 2 (Wombat)',
     rootPath: '/v2',
     routes: V2routes,
+    id: 2,
   },
 });
 
@@ -35,5 +36,6 @@ export const V3 = createStory(Template, {
     name: 'Version 3 (V3)',
     rootPath: '/v3',
     routes: V3routes,
+    id: 3,
   },
 });

--- a/client/src/components/common/navbar/NavBar.tsx
+++ b/client/src/components/common/navbar/NavBar.tsx
@@ -40,8 +40,8 @@ export default function NavBar({
     </Nav.Link>
   ));
 
-  const versionDropdown = bikeVersions.map(({ name, rootPath }) => (
-    <NavDropdown.Item as={NavLink} to={rootPath} activeClassName="">
+  const versionDropdown = bikeVersions.map(({ name, rootPath, id }) => (
+    <NavDropdown.Item as={NavLink} to={rootPath} activeClassName="" key={id}>
       {name}
     </NavDropdown.Item>
   ));

--- a/client/src/router/index.ts
+++ b/client/src/router/index.ts
@@ -11,6 +11,8 @@ export interface VersionInfo {
   rootPath: string;
   /** List of routes under this version */
   routes: RouteInfo[];
+  /** Key for React mapping */
+  id: number;
 }
 
 export const bikeVersions: VersionInfo[] = [
@@ -18,11 +20,13 @@ export const bikeVersions: VersionInfo[] = [
     name: 'Version 2 (Wombat)',
     rootPath: '/v2',
     routes: V2Routes,
+    id: 2,
   },
   {
     name: 'Version 3 (V3)',
     rootPath: '/v3',
     routes: V3Routes,
+    id: 3,
   },
 ];
 


### PR DESCRIPTION
Added keys to navigational bar lists to remove warning showing up during development

## Description

During development a warning regarding list keys comes up. This was not present during production because it only occurs during compiling. No performance improvements are expected from removing the warning, but it's gone.

## Screenshots

In the NavBar.stories.tsx and index.tx I added an 'id' field so that React can keep track of the items, then in NavBar.tsx I added "key={id}".

Nothing should appear differently in the site, only a lack of warning in the console during development and compiling.
